### PR TITLE
feat: add clean database command

### DIFF
--- a/cmd/docker.go
+++ b/cmd/docker.go
@@ -21,5 +21,6 @@ func init() {
 	dockerCmd.AddCommand(docker.PopulateCmd)
 	dockerCmd.AddCommand(docker.ExportCmd)
 	dockerCmd.AddCommand(docker.ListCmd)
+	dockerCmd.AddCommand(docker.CleanCmd)
 	rootCmd.AddCommand(dockerCmd)
 }

--- a/cmd/docker/clean.go
+++ b/cmd/docker/clean.go
@@ -1,0 +1,27 @@
+// Package docker contains the internal functions used by the docker cmd to manage environments
+package docker
+
+import (
+	"github.com/epos-eu/epos-opensource/cmd/docker/dockercore"
+	"github.com/epos-eu/epos-opensource/display"
+
+	"github.com/spf13/cobra"
+)
+
+var CleanCmd = &cobra.Command{
+	Use:   "clean [env-name]",
+	Short: "Removes the volume of the metadata database.",
+	Long:  "Stops the metadata database, removes the volume associated to it and re-deloys the container.",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		name := args[0]
+
+		err := dockercore.Clean(dockercore.CleanOpts{
+			Name: name,
+		})
+		if err != nil {
+			display.Error("%v", err)
+			return
+		}
+	},
+}

--- a/cmd/docker/dockercore/clean.go
+++ b/cmd/docker/dockercore/clean.go
@@ -1,0 +1,85 @@
+package dockercore
+
+import (
+	_ "embed"
+	"fmt"
+	"os/exec"
+
+	"github.com/epos-eu/epos-opensource/command"
+	"github.com/epos-eu/epos-opensource/common"
+	"github.com/epos-eu/epos-opensource/db"
+	"github.com/epos-eu/epos-opensource/validate"
+)
+
+type CleanOpts struct {
+	// Required. name of the environment
+	Name string
+}
+
+func Clean(opts CleanOpts) error {
+	if err := opts.Validate(); err != nil {
+		return fmt.Errorf("invalid clean parameters: %w", err)
+	}
+
+	docker, err := db.GetDockerByName(opts.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get docker info for %s: %w", opts.Name, err)
+	}
+	ports := &DeploymentPorts{
+		GUI:        int(docker.GuiPort),
+		API:        int(docker.ApiPort),
+		Backoffice: int(docker.BackofficePort),
+	}
+	metadataContainer := fmt.Sprintf("%s-metadata-database", opts.Name)
+	backOfficeContainer := fmt.Sprintf("%s-backoffice-service", opts.Name)
+	ingestorContainer := fmt.Sprintf("%s-ingestor-service", opts.Name)
+	externalAccContainer := fmt.Sprintf("%s-external-access-service", opts.Name)
+	resorceContainer := fmt.Sprintf("%s-resources-service", opts.Name)
+	volumeName := fmt.Sprintf("%s_psqldata", opts.Name)
+
+	if _, err := command.RunCommand(exec.Command("docker", "stop", metadataContainer), false); err != nil {
+		return fmt.Errorf("failed to stop %s: %w", metadataContainer, err)
+	}
+
+	if _, err := command.RunCommand(exec.Command("docker", "rm", "-v", metadataContainer), false); err != nil {
+		return fmt.Errorf("failed to remove %s: %w", metadataContainer, err)
+	}
+
+	if _, err := command.RunCommand(exec.Command("docker", "volume", "rm", volumeName), false); err != nil {
+		return fmt.Errorf("failed to remove volume %s: %w", volumeName, err)
+	}
+
+	if _, err := command.RunCommand(exec.Command("docker", "stop", backOfficeContainer), false); err != nil {
+		return fmt.Errorf("failed to stop %s: %w", backOfficeContainer, err)
+	}
+
+	if _, err := command.RunCommand(exec.Command("docker", "stop", ingestorContainer), false); err != nil {
+		return fmt.Errorf("failed to stop %s: %w", ingestorContainer, err)
+	}
+
+	if _, err := command.RunCommand(exec.Command("docker", "stop", externalAccContainer), false); err != nil {
+		return fmt.Errorf("failed to stop %s: %w", externalAccContainer, err)
+	}
+
+	if _, err := command.RunCommand(exec.Command("docker", "stop", resorceContainer), false); err != nil {
+		return fmt.Errorf("failed to stop %s: %w", externalAccContainer, err)
+	}
+
+	if _, err := deployStack(docker.Directory, opts.Name, ports, ""); err != nil {
+		return fmt.Errorf("failed to redeploy the metadata database for %s: %w", opts.Name, err)
+	}
+
+	if err := common.PopulateOntologies(docker.ApiUrl); err != nil {
+		return fmt.Errorf("failed to populate base ontologies in environment %s: %w", opts.Name, err)
+	}
+
+	return nil
+}
+
+func (c *CleanOpts) Validate() error {
+	if err := validate.EnvironmentExistsDocker(c.Name); err != nil {
+		return fmt.Errorf("no environment with the name '%s' exists: %w", c.Name, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--
Title: <type>(<scope>): <summary>
Examples: fix(auth): handle expired refresh token
          feat(cli): add --dry-run flag
-->

> Prefer a different template?
>
> - **New to project**: [use this guided template](?expand=1&template=new-to-project.md)

## Summary

<!-- 1–3 sentences: what and why -->
add clean command that cleans the database of injected .ttl files, this helps avoid having to delete and re deploy the containers every time to delete the database

## Linked Issues

<!-- If any -->

Closes #

## How to Test

<!-- Copy/paste steps & example commands (include kube context/namespace if relevant) -->
epos-opensource docker clean [env-name]
---

## Checklist (Required)

- [x] Builds locally with no errors (`make build`).
- [x] Linter passes (`make lint`) and tests pass (`make test`).
- [x] No secrets/keys/tokens added.
- [x] CLI behavior and flags remain backward compatible **or** breaking changes are documented here.

## Checklist (Recommended)

- [x] Docs/help/examples updated if behavior/flags changed.
- [x] Edge cases considered (empty inputs, timeouts, invalid paths).

---

## Reviewer Notes

<!-- Files or areas to focus on, tradeoffs, known limitations -->
