### PR TITLE
feat(auth): add embedded AAI support to docker and k8s

### DIFF
--- a/common/imagecheck.go
+++ b/common/imagecheck.go
@@ -39,6 +39,7 @@ type Images struct {
 	BackofficeUIImage       string `yaml:"backoffice_ui_image"`
 	EmailSenderServiceImage string `yaml:"email_sender_service_image"`
 	SharingServiceImage     string `yaml:"sharing_service_image"`
+	AAIServiceImage         string `yaml:"aai_service_image"`
 }
 
 func ImageExistsLocally(ctx context.Context, imageRef string) (bool, error) {

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -129,6 +129,14 @@ func (e *EnvConfig) CheckForUpdates() ([]display.ImageUpdateInfo, error) {
 	return updates, nil
 }
 
+func validateAuthDependsOnGatewayAAI(serviceName string, auth Auth, gatewayAAIEnabled bool) error {
+	if auth.Enabled && !gatewayAAIEnabled {
+		return fmt.Errorf("%s auth requires gateway aai to be enabled", serviceName)
+	}
+
+	return nil
+}
+
 // EnsurePortsFree verifies default service ports are available and auto-selects free ones when needed.
 func (e *EnvConfig) EnsurePortsFree() error {
 	if !e.UsingDefaultPorts() {
@@ -239,14 +247,61 @@ func (e *EnvConfig) Validate() error {
 	}
 
 	// AAI validation
-	if e.Components.Gateway.Aai.Enabled {
-		if e.Components.Gateway.Aai.ServiceEndpoint == "" {
+	if e.Components.AAIService.Enabled {
+		if !e.Components.Gateway.AAI.Enabled {
+			return fmt.Errorf("aai service is enabled but aai in the gateway is disabled")
+		}
+		if e.Components.AAIService.Port == 0 {
+			return fmt.Errorf("aai service port is required when aai service is enabled")
+		}
+		if e.Components.AAIService.Port < 1 || e.Components.AAIService.Port > 65535 {
+			return fmt.Errorf("aai service port must be between 1 and 65535")
+		}
+		if e.Components.AAIService.Name == "" {
+			return fmt.Errorf("aai service name is required when aai service is enabled")
+		}
+		if e.Components.AAIService.Surname == "" {
+			return fmt.Errorf("aai service surname is required when aai service is enabled")
+		}
+		if e.Components.AAIService.Email == "" {
+			return fmt.Errorf("aai service email is required when aai service is enabled")
+		}
+		if e.Components.AAIService.Password == "" {
+			return fmt.Errorf("aai service password is required when aai service is enabled")
+		}
+		if e.Images.AAIServiceImage == "" {
+			return fmt.Errorf("aai service image is required when aai service is enabled")
+		}
+	}
+	if e.Components.Gateway.AAI.Enabled {
+		if e.Components.Gateway.AAI.ServiceEndpoint == "" {
 			return fmt.Errorf("aai service endpoint is required when aai is enabled")
+		}
+	}
+
+	authValidations := []struct {
+		serviceName string
+		auth        Auth
+	}{
+		{serviceName: "backoffice service", auth: e.Components.Backoffice.Service.Auth},
+		{serviceName: "converter service", auth: e.Components.Converter.Auth},
+		{serviceName: "resources service", auth: e.Components.ResourcesService.Auth},
+		{serviceName: "ingestor service", auth: e.Components.IngestorService.Auth},
+		{serviceName: "external access service", auth: e.Components.ExternalAccessService.Auth},
+		{serviceName: "sharing service", auth: e.Components.SharingService.Auth},
+		{serviceName: "email sender service", auth: e.Components.EmailSenderService.Auth},
+	}
+	for _, validation := range authValidations {
+		if err := validateAuthDependsOnGatewayAAI(validation.serviceName, validation.auth, e.Components.Gateway.AAI.Enabled); err != nil {
+			return err
 		}
 	}
 
 	// Backoffice validation
 	if e.Components.Backoffice.Enabled {
+		if !e.Components.Backoffice.Service.Auth.Enabled {
+			return fmt.Errorf("backoffice service auth must be enabled when backoffice is enabled")
+		}
 		if e.Components.Backoffice.GUI.BaseURL == "" {
 			return fmt.Errorf("backoffice base url is required when backoffice is enabled")
 		}

--- a/pkg/docker/config/config_validate_test.go
+++ b/pkg/docker/config/config_validate_test.go
@@ -105,3 +105,216 @@ func TestEnvConfigValidate_MetadataDatabasePublishedPortIsOptional(t *testing.T)
 		t.Fatalf("Validate() error = %v, want nil", err)
 	}
 }
+
+func TestEnvConfigValidate_AAI(t *testing.T) {
+	tests := []struct {
+		name        string
+		mutate      func(cfg *config.EnvConfig)
+		errContains string
+	}{
+		{
+			name: "aai service requires gateway aai",
+			mutate: func(cfg *config.EnvConfig) {
+				cfg.Components.AAIService.Enabled = true
+			},
+			errContains: "aai service is enabled but aai in the gateway is disabled",
+		},
+		{
+			name: "aai service port is required when enabled",
+			mutate: func(cfg *config.EnvConfig) {
+				cfg.Components.Gateway.AAI.Enabled = true
+				cfg.Components.AAIService.Enabled = true
+				cfg.Components.AAIService.Port = 0
+			},
+			errContains: "aai service port is required when aai service is enabled",
+		},
+		{
+			name: "aai service port must be within range",
+			mutate: func(cfg *config.EnvConfig) {
+				cfg.Components.Gateway.AAI.Enabled = true
+				cfg.Components.AAIService.Enabled = true
+				cfg.Components.AAIService.Port = 70000
+			},
+			errContains: "aai service port must be between 1 and 65535",
+		},
+		{
+			name: "aai service name is required when enabled",
+			mutate: func(cfg *config.EnvConfig) {
+				cfg.Components.Gateway.AAI.Enabled = true
+				cfg.Components.AAIService.Enabled = true
+				cfg.Components.AAIService.Name = ""
+			},
+			errContains: "aai service name is required when aai service is enabled",
+		},
+		{
+			name: "aai service surname is required when enabled",
+			mutate: func(cfg *config.EnvConfig) {
+				cfg.Components.Gateway.AAI.Enabled = true
+				cfg.Components.AAIService.Enabled = true
+				cfg.Components.AAIService.Surname = ""
+			},
+			errContains: "aai service surname is required when aai service is enabled",
+		},
+		{
+			name: "aai service email is required when enabled",
+			mutate: func(cfg *config.EnvConfig) {
+				cfg.Components.Gateway.AAI.Enabled = true
+				cfg.Components.AAIService.Enabled = true
+				cfg.Components.AAIService.Email = ""
+			},
+			errContains: "aai service email is required when aai service is enabled",
+		},
+		{
+			name: "aai service password is required when enabled",
+			mutate: func(cfg *config.EnvConfig) {
+				cfg.Components.Gateway.AAI.Enabled = true
+				cfg.Components.AAIService.Enabled = true
+				cfg.Components.AAIService.Password = ""
+			},
+			errContains: "aai service password is required when aai service is enabled",
+		},
+		{
+			name: "aai service image is required when enabled",
+			mutate: func(cfg *config.EnvConfig) {
+				cfg.Components.Gateway.AAI.Enabled = true
+				cfg.Components.AAIService.Enabled = true
+				cfg.Images.AAIServiceImage = ""
+			},
+			errContains: "aai service image is required when aai service is enabled",
+		},
+		{
+			name: "gateway aai requires service endpoint",
+			mutate: func(cfg *config.EnvConfig) {
+				cfg.Components.Gateway.AAI.Enabled = true
+				cfg.Components.Gateway.AAI.ServiceEndpoint = ""
+			},
+			errContains: "aai service endpoint is required when aai is enabled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NewTestConfig(t, "test-env").Build()
+			tt.mutate(cfg)
+
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("Validate() error = nil, want error containing %q", tt.errContains)
+			}
+
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("Validate() error = %q, want substring %q", err.Error(), tt.errContains)
+			}
+		})
+	}
+}
+
+func TestEnvConfigValidate_GatewayAAIWithExternalEndpointIsValid(t *testing.T) {
+	cfg := NewTestConfig(t, "test-env").Build()
+	cfg.Components.Gateway.AAI.Enabled = true
+	cfg.Components.Gateway.AAI.ServiceEndpoint = "https://auth.example.com/oauth2/userinfo"
+	cfg.Components.AAIService.Enabled = false
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestEnvConfigValidate_BackofficeRequiresAuth(t *testing.T) {
+	cfg := NewTestConfig(t, "test-env").WithBackoffice(true).Build()
+	cfg.Components.Backoffice.Service.Auth.Enabled = false
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want error")
+	}
+
+	if !strings.Contains(err.Error(), "backoffice service auth must be enabled when backoffice is enabled") {
+		t.Fatalf("Validate() error = %q, want substring %q", err.Error(), "backoffice service auth must be enabled when backoffice is enabled")
+	}
+}
+
+func TestEnvConfigValidate_ServiceAuthRequiresGatewayAAI(t *testing.T) {
+	tests := []struct {
+		name        string
+		mutate      func(cfg *config.EnvConfig)
+		errContains string
+	}{
+		{
+			name: "backoffice service auth requires gateway aai",
+			mutate: func(cfg *config.EnvConfig) {
+				cfg.Components.Backoffice.Service.Auth.Enabled = true
+			},
+			errContains: "backoffice service auth requires gateway aai to be enabled",
+		},
+		{
+			name: "converter service auth requires gateway aai",
+			mutate: func(cfg *config.EnvConfig) {
+				cfg.Components.Converter.Auth.Enabled = true
+			},
+			errContains: "converter service auth requires gateway aai to be enabled",
+		},
+		{
+			name: "resources service auth requires gateway aai",
+			mutate: func(cfg *config.EnvConfig) {
+				cfg.Components.ResourcesService.Auth.Enabled = true
+			},
+			errContains: "resources service auth requires gateway aai to be enabled",
+		},
+		{
+			name: "ingestor service auth requires gateway aai",
+			mutate: func(cfg *config.EnvConfig) {
+				cfg.Components.IngestorService.Auth.Enabled = true
+			},
+			errContains: "ingestor service auth requires gateway aai to be enabled",
+		},
+		{
+			name: "external access service auth requires gateway aai",
+			mutate: func(cfg *config.EnvConfig) {
+				cfg.Components.ExternalAccessService.Auth.Enabled = true
+			},
+			errContains: "external access service auth requires gateway aai to be enabled",
+		},
+		{
+			name: "sharing service auth requires gateway aai",
+			mutate: func(cfg *config.EnvConfig) {
+				cfg.Components.SharingService.Auth.Enabled = true
+			},
+			errContains: "sharing service auth requires gateway aai to be enabled",
+		},
+		{
+			name: "email sender service auth requires gateway aai",
+			mutate: func(cfg *config.EnvConfig) {
+				cfg.Components.EmailSenderService.Auth.Enabled = true
+			},
+			errContains: "email sender service auth requires gateway aai to be enabled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NewTestConfig(t, "test-env").Build()
+			tt.mutate(cfg)
+
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("Validate() error = nil, want error containing %q", tt.errContains)
+			}
+
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("Validate() error = %q, want substring %q", err.Error(), tt.errContains)
+			}
+		})
+	}
+}
+
+func TestEnvConfigValidate_ServiceAuthIsValidWithGatewayAAI(t *testing.T) {
+	cfg := NewTestConfig(t, "test-env").Build()
+	cfg.Components.Gateway.AAI.Enabled = true
+	cfg.Components.Gateway.AAI.ServiceEndpoint = "https://auth.example.com/oauth2/userinfo"
+	cfg.Components.ResourcesService.Auth.Enabled = true
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}

--- a/pkg/docker/config/config_validate_test.go
+++ b/pkg/docker/config/config_validate_test.go
@@ -7,7 +7,9 @@ import (
 	"github.com/EPOS-ERIC/epos-opensource/pkg/docker/config"
 )
 
-const externalAAIUserinfoEndpoint = "https://auth.example.com/oauth2/userinfo"
+const (
+	externalAAIUserinfoEndpoint = "https://auth.example.com/oauth2/userinfo"
+)
 
 func TestEnvConfigValidate_RequiresCoreImages(t *testing.T) {
 	tests := []struct {
@@ -233,6 +235,17 @@ func TestEnvConfigValidate_BackofficeRequiresAuth(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "backoffice service auth must be enabled when backoffice is enabled") {
 		t.Fatalf("Validate() error = %q, want substring %q", err.Error(), "backoffice service auth must be enabled when backoffice is enabled")
+	}
+}
+
+func TestEnvConfigValidate_BackofficeWithoutEmbeddedAAIIsValid(t *testing.T) {
+	cfg := NewTestConfig(t, "test-env").WithBackoffice(true).Build()
+	cfg.Components.Gateway.AAI.Enabled = true
+	cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIUserinfoEndpoint
+	cfg.Components.AAIService.Enabled = false
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
 	}
 }
 

--- a/pkg/docker/config/config_validate_test.go
+++ b/pkg/docker/config/config_validate_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/EPOS-ERIC/epos-opensource/pkg/docker/config"
 )
 
+const externalAAIUserinfoEndpoint = "https://auth.example.com/oauth2/userinfo"
+
 func TestEnvConfigValidate_RequiresCoreImages(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -212,7 +214,7 @@ func TestEnvConfigValidate_AAI(t *testing.T) {
 func TestEnvConfigValidate_GatewayAAIWithExternalEndpointIsValid(t *testing.T) {
 	cfg := NewTestConfig(t, "test-env").Build()
 	cfg.Components.Gateway.AAI.Enabled = true
-	cfg.Components.Gateway.AAI.ServiceEndpoint = "https://auth.example.com/oauth2/userinfo"
+	cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIUserinfoEndpoint
 	cfg.Components.AAIService.Enabled = false
 
 	if err := cfg.Validate(); err != nil {
@@ -311,7 +313,7 @@ func TestEnvConfigValidate_ServiceAuthRequiresGatewayAAI(t *testing.T) {
 func TestEnvConfigValidate_ServiceAuthIsValidWithGatewayAAI(t *testing.T) {
 	cfg := NewTestConfig(t, "test-env").Build()
 	cfg.Components.Gateway.AAI.Enabled = true
-	cfg.Components.Gateway.AAI.ServiceEndpoint = "https://auth.example.com/oauth2/userinfo"
+	cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIUserinfoEndpoint
 	cfg.Components.ResourcesService.Auth.Enabled = true
 
 	if err := cfg.Validate(); err != nil {

--- a/pkg/docker/config/default.yaml
+++ b/pkg/docker/config/default.yaml
@@ -16,10 +16,13 @@ components:
     port: 33000
 
     aai:
-      # Enable/disable AAI (Authentication and Authorization Infrastructure) integration
+      # Enable/disable AAI (Authentication and Authorization Infrastructure) integration in the gateway.
+      # When enabled, the gateway will call the configured userinfo endpoint to validate authenticated requests.
+      # This can point to the embedded aai_service below or to an external provider.
       enabled: false
-      # AAI service endpoint URL (required when AAI is enabled)
-      service_endpoint: ""
+      # Userinfo endpoint used by the gateway when AAI is enabled.
+      # Use the embedded service default below for local auth, or replace it with an external provider endpoint.
+      service_endpoint: "http://aai-service:8080/oauth2/userinfo"
 
     # Base URL path for the API gateway. Must start with / and end with /api/v1
     base_url: "/api/v1"
@@ -154,6 +157,19 @@ components:
     # API key for authenticating with the email service
     mail_api_key: "changeme"
 
+  aai_service:
+    # Enable/disable the embedded local AAI service container.
+    # This is optional: the gateway can use an external AAI provider with this disabled.
+    # If you enable this service, gateway.aai.enabled must also be enabled.
+    enabled: false
+    # Host port used to expose the embedded AAI service locally
+    port: 35000
+    # Initial admin user seeded into the embedded AAI service on first startup
+    name: "EPOS"
+    surname: "User"
+    email: "epos@epos.eu"
+    password: "epos"
+
 monitoring:
   # Enable/disable monitoring integration
   enabled: false
@@ -182,3 +198,4 @@ images:
   backoffice_ui_image: "ghcr.io/epos-eric/epos-backoffice-gui:latest"
   email_sender_service_image: "ghcr.io/epos-eric/email-sender-service:latest"
   sharing_service_image: "ghcr.io/epos-eric/sharing-service:latest"
+  aai_service_image: "ghcr.io/epos-eric/oss-aai-service:latest"

--- a/pkg/docker/config/model.go
+++ b/pkg/docker/config/model.go
@@ -18,8 +18,8 @@ type PlatformGUI struct {
 	Port    int    `yaml:"port"`
 }
 
-// Aai configures AAI integration for gateway services.
-type Aai struct {
+// AAI configures AAI integration for gateway services.
+type AAI struct {
 	Enabled         bool   `yaml:"enabled"`
 	ServiceEndpoint string `yaml:"service_endpoint"`
 }
@@ -33,7 +33,7 @@ type SwaggerPage struct {
 
 // Gateway configures gateway URLs, port, and auth integrations.
 type Gateway struct {
-	Aai         Aai         `yaml:"aai"`
+	AAI         AAI         `yaml:"aai"`
 	BaseURL     string      `yaml:"base_url"`
 	SwaggerPage SwaggerPage `yaml:"swagger_page"`
 	Port        int         `yaml:"port"`
@@ -131,6 +131,15 @@ type EmailSenderService struct {
 	MailAPIKey      string `yaml:"mail_api_key"`
 }
 
+type AAIService struct {
+	Enabled  bool   `yaml:"enabled"`
+	Port     int    `yaml:"port"`
+	Name     string `yaml:"name"`
+	Surname  string `yaml:"surname"`
+	Email    string `yaml:"email"`
+	Password string `yaml:"password"`
+}
+
 // Components groups all service-level component settings.
 type Components struct {
 	PlatformGUI           PlatformGUI           `yaml:"platform_gui"`
@@ -144,6 +153,7 @@ type Components struct {
 	Rabbitmq              Rabbitmq              `yaml:"rabbitmq"`
 	MetadataDatabase      MetadataDatabase      `yaml:"metadata_database"`
 	EmailSenderService    EmailSenderService    `yaml:"email_sender_service"`
+	AAIService            AAIService            `yaml:"aai_service"`
 }
 
 // Monitoring configures optional monitoring integration.
@@ -187,6 +197,10 @@ func (e *EnvConfig) ActiveImages() []common.NamedImage {
 
 	if e.Components.SharingService.Enabled {
 		images = append(images, common.NamedImage{Name: "Sharing Service", Ref: e.Images.SharingServiceImage})
+	}
+
+	if e.Components.AAIService.Enabled {
+		images = append(images, common.NamedImage{Name: "AAI Service", Ref: e.Images.AAIServiceImage})
 	}
 
 	return images

--- a/pkg/docker/config/render_test.go
+++ b/pkg/docker/config/render_test.go
@@ -51,7 +51,7 @@ func TestDockerEnvConfig_Render(t *testing.T) {
 			wantErr: false,
 			wantContains: map[string][]string{
 				".env":                {"AUTH_ROOT_URL=http://localhost:35000"},
-				"docker-compose.yaml": {"dataportal:", "backoffice-ui:", "AUTH_ROOT_URL=${AUTH_ROOT_URL}"},
+				"docker-compose.yaml": {"dataportal:", "backoffice-ui:", "- AUTH_ROOT_URL"},
 			},
 		},
 		{

--- a/pkg/docker/config/render_test.go
+++ b/pkg/docker/config/render_test.go
@@ -41,6 +41,20 @@ func TestDockerEnvConfig_Render(t *testing.T) {
 			},
 		},
 		{
+			name: "backoffice uses embedded aai auth root url by default",
+			config: func() *config.EnvConfig {
+				cfg := NewTestConfig(t, "test-bo-aai").WithBackoffice(true).Build()
+				cfg.Components.Gateway.AAI.Enabled = true
+				cfg.Components.AAIService.Enabled = true
+				return cfg
+			}(),
+			wantErr: false,
+			wantContains: map[string][]string{
+				".env":                {"AUTH_ROOT_URL=http://localhost:35000"},
+				"docker-compose.yaml": {"dataportal:", "backoffice-ui:", "AUTH_ROOT_URL=${AUTH_ROOT_URL}"},
+			},
+		},
+		{
 			name:    "backoffice disabled excludes backoffice from compose",
 			config:  NewTestConfig(t, "test-no-bo").Build(),
 			wantErr: false,

--- a/pkg/docker/config/render_test.go
+++ b/pkg/docker/config/render_test.go
@@ -76,6 +76,48 @@ func TestDockerEnvConfig_Render(t *testing.T) {
 			},
 		},
 		{
+			name: "embedded aai enabled includes aai service and env vars",
+			config: func() *config.EnvConfig {
+				cfg := NewTestConfig(t, "test-aai").Build()
+				cfg.Components.Gateway.AAI.Enabled = true
+				cfg.Components.AAIService.Enabled = true
+				return cfg
+			}(),
+			wantErr: false,
+			wantContains: map[string][]string{
+				".env": {
+					"IS_AAI_ENABLED=true",
+					"AAI_SERVICE_ENDPOINT=http://aai-service:8080/oauth2/userinfo",
+					"ADMIN_NAME=EPOS",
+					"ADMIN_SURNAME=User",
+					"ADMIN_EMAIL=epos@epos.eu",
+					"ADMIN_PASSWORD=epos",
+					"AAI_SERVICE_PORT=35000",
+				},
+				"docker-compose.yaml": {"aai-service:", "${AAI_SERVICE_PORT}:8080"},
+			},
+		},
+		{
+			name: "embedded aai disabled excludes service specific env vars and compose service",
+			config: func() *config.EnvConfig {
+				cfg := NewTestConfig(t, "test-external-aai").Build()
+				cfg.Components.Gateway.AAI.Enabled = true
+				cfg.Components.Gateway.AAI.ServiceEndpoint = "https://auth.example.com/oauth2/userinfo"
+				return cfg
+			}(),
+			wantErr: false,
+			wantContains: map[string][]string{
+				".env": {
+					"IS_AAI_ENABLED=true",
+					"AAI_SERVICE_ENDPOINT=https://auth.example.com/oauth2/userinfo",
+				},
+			},
+			notContains: map[string][]string{
+				".env":                {"ADMIN_NAME=", "ADMIN_SURNAME=", "ADMIN_EMAIL=", "ADMIN_PASSWORD=", "AAI_SERVICE_PORT="},
+				"docker-compose.yaml": {"aai-service:"},
+			},
+		},
+		{
 			name: "metadata database published port is rendered when configured",
 			config: func() *config.EnvConfig {
 				cfg := NewTestConfig(t, "test-db-port").Build()

--- a/pkg/docker/config/render_test.go
+++ b/pkg/docker/config/render_test.go
@@ -102,14 +102,14 @@ func TestDockerEnvConfig_Render(t *testing.T) {
 			config: func() *config.EnvConfig {
 				cfg := NewTestConfig(t, "test-external-aai").Build()
 				cfg.Components.Gateway.AAI.Enabled = true
-				cfg.Components.Gateway.AAI.ServiceEndpoint = "https://auth.example.com/oauth2/userinfo"
+				cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIUserinfoEndpoint
 				return cfg
 			}(),
 			wantErr: false,
 			wantContains: map[string][]string{
 				".env": {
 					"IS_AAI_ENABLED=true",
-					"AAI_SERVICE_ENDPOINT=https://auth.example.com/oauth2/userinfo",
+					"AAI_SERVICE_ENDPOINT=" + externalAAIUserinfoEndpoint,
 				},
 			},
 			notContains: map[string][]string{

--- a/pkg/docker/config/templates/.env.tmpl
+++ b/pkg/docker/config/templates/.env.tmpl
@@ -63,8 +63,15 @@ LOAD_SHARING_API={{.Components.SharingService.Auth.Enabled}}:{{.Components.Shari
 {{- end}}
 
 # if setting this to true make sure to also set the AAI_SERVICE_ENDPOINT variable to a compatible provider
-IS_AAI_ENABLED={{.Components.Gateway.Aai.Enabled}}
-AAI_SERVICE_ENDPOINT={{.Components.Gateway.Aai.ServiceEndpoint}}
+IS_AAI_ENABLED={{.Components.Gateway.AAI.Enabled}}
+AAI_SERVICE_ENDPOINT={{.Components.Gateway.AAI.ServiceEndpoint}}
+
+{{- if .Components.AAIService.Enabled}}
+ADMIN_NAME={{.Components.AAIService.Name}}
+ADMIN_SURNAME={{.Components.AAIService.Surname}}
+ADMIN_EMAIL={{.Components.AAIService.Email}}
+ADMIN_PASSWORD={{.Components.AAIService.Password}}
+{{- end}}
 
 # RabbitMQ Broker
 RABBITMQ_HOST={{.Components.Rabbitmq.Host}}
@@ -90,6 +97,9 @@ GATEWAY_PORT={{.Components.Gateway.Port}}
 {{- if .Components.Backoffice.Enabled}}
 BACKOFFICE_PORT={{.Components.Backoffice.GUI.Port}}
 {{- end}}
+{{- if .Components.AAIService.Enabled}}
+AAI_SERVICE_PORT={{.Components.AAIService.Port}}
+{{- end}}
 
 # Docker Images and Tags
 RABBITMQ_IMAGE="{{.Images.RabbitmqImage}}"
@@ -105,3 +115,4 @@ BACKOFFICE_SERVICE_IMAGE="{{.Images.BackofficeServiceImage}}"
 BACKOFFICE_UI_IMAGE="{{.Images.BackofficeUIImage}}"
 EMAIL_SENDER_SERVICE_IMAGE="{{.Images.EmailSenderServiceImage}}"
 SHARING_SERVICE_IMAGE="{{.Images.SharingServiceImage}}"
+AAI_SERVICE_IMAGE="{{.Images.AAIServiceImage}}"

--- a/pkg/docker/config/templates/.env.tmpl
+++ b/pkg/docker/config/templates/.env.tmpl
@@ -99,6 +99,7 @@ BACKOFFICE_PORT={{.Components.Backoffice.GUI.Port}}
 {{- end}}
 {{- if .Components.AAIService.Enabled}}
 AAI_SERVICE_PORT={{.Components.AAIService.Port}}
+AUTH_ROOT_URL={{.Protocol}}://{{.Domain}}:{{.Components.AAIService.Port}}
 {{- end}}
 
 # Docker Images and Tags

--- a/pkg/docker/config/templates/docker-compose.yaml.tmpl
+++ b/pkg/docker/config/templates/docker-compose.yaml.tmpl
@@ -376,9 +376,34 @@ services:
     networks:
       - epos_network
 
+{{- if .Components.AAIService.Enabled}}
+  aai-service:
+    image: ${AAI_SERVICE_IMAGE}
+    container_name: ${ENV_NAME:-epos-platform}-aai-service
+    ports:
+      - "${AAI_SERVICE_PORT}:8080"
+    volumes:
+      - aai:/app/data
+    networks:
+      - epos_network
+    restart: always
+    environment:
+	  {{- if eq .Protocol "https"}}
+      - APP_SECURE_COOKIES=true
+	  {{- else}}
+      - APP_SECURE_COOKIES=false
+	  {{- end}}
+      - INITIAL_ADMIN_NAME=${ADMIN_NAME}
+      - INITIAL_ADMIN_SURNAME=${ADMIN_SURNAME}
+      - INITIAL_ADMIN_EMAIL=${ADMIN_EMAIL}
+      - INITIAL_ADMIN_PASSWORD=${ADMIN_PASSWORD}
+      - APP_CORS_ALLOW_ORIGIN={{.Protocol}}://{{.Domain}}:{{.Components.Backoffice.GUI.Port}}
+{{- end}}
+
 volumes:
   converter:
   psqldata:
+  aai:
 
 networks:
   epos_network:

--- a/pkg/docker/config/templates/docker-compose.yaml.tmpl
+++ b/pkg/docker/config/templates/docker-compose.yaml.tmpl
@@ -10,6 +10,7 @@ services:
     environment:
       - BASE_URL=${DATAPORTAL_PATH}
       - API_HOST=http://gateway:5000/api
+      - AUTH_ROOT_URL
     depends_on:
       gateway:
         condition: service_healthy
@@ -26,6 +27,7 @@ services:
     environment:
       - BASE_URL=${BACKOFFICE_PATH}
       - API_HOST=http://gateway:5000/api
+      - AUTH_ROOT_URL
     depends_on:
       gateway:
         condition: service_healthy
@@ -401,7 +403,13 @@ services:
       - INITIAL_ADMIN_SURNAME=${ADMIN_SURNAME}
       - INITIAL_ADMIN_EMAIL=${ADMIN_EMAIL}
       - INITIAL_ADMIN_PASSWORD=${ADMIN_PASSWORD}
-      - APP_CORS_ALLOW_ORIGIN={{.Protocol}}://{{.Domain}}:{{.Components.Backoffice.GUI.Port}}
+      - APP_CORS_ALLOW_ORIGIN=*
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:8080/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 {{- end}}
 
 volumes:

--- a/pkg/docker/config/templates/docker-compose.yaml.tmpl
+++ b/pkg/docker/config/templates/docker-compose.yaml.tmpl
@@ -109,6 +109,10 @@ services:
       sharing-service:
         condition: service_healthy
 	{{- end}}
+	{{- if .Components.AAIService.Enabled}}
+      aai-service:
+        condition: service_healthy
+	{{- end}}
 
   rabbitmq:
     image: ${RABBITMQ_IMAGE}

--- a/pkg/docker/config/testing_test.go
+++ b/pkg/docker/config/testing_test.go
@@ -75,11 +75,15 @@ func (b *TestConfigBuilder) Build() *config.EnvConfig {
 			Gateway: config.Gateway{
 				BaseURL: "/api/v1",
 				Port:    b.gatewayPort,
+				AAI: config.AAI{
+					Enabled:         false,
+					ServiceEndpoint: "http://aai-service:8080/oauth2/userinfo",
+				},
 			},
 			Backoffice: config.Backoffice{
 				Enabled: b.backofficeEnabled,
 				GUI:     config.GUI{BaseURL: "/backoffice", Port: 34000},
-				Service: config.Service{Auth: config.Auth{Enabled: false, OnlyAdmin: false}},
+				Service: config.Service{Auth: config.Auth{Enabled: b.backofficeEnabled, OnlyAdmin: false}},
 			},
 			Converter: config.Converter{
 				Enabled: b.converterEnabled,
@@ -133,6 +137,14 @@ func (b *TestConfigBuilder) Build() *config.EnvConfig {
 				MailAPIURL:      "https://api.example.email/",
 				MailAPIKey:      "changeme",
 			},
+			AAIService: config.AAIService{
+				Enabled:  false,
+				Port:     35000,
+				Name:     "EPOS",
+				Surname:  "User",
+				Email:    "epos@epos.eu",
+				Password: "epos",
+			},
 		},
 		Monitoring: config.Monitoring{
 			Enabled: false,
@@ -151,6 +163,7 @@ func (b *TestConfigBuilder) Build() *config.EnvConfig {
 			BackofficeUIImage:       "epos/backoffice-ui:latest",
 			EmailSenderServiceImage: "ghcr.io/epos-eric/email-sender-service:latest",
 			SharingServiceImage:     "ghcr.io/epos-eric/sharing-service:latest",
+			AAIServiceImage:         "ghcr.io/epos-eric/oss-aai-service:latest",
 		},
 	}
 }

--- a/pkg/k8s/config/config.go
+++ b/pkg/k8s/config/config.go
@@ -117,6 +117,14 @@ func (c *Config) BuildEnvURLs() (*common.URLs, error) {
 	return urls, nil
 }
 
+func validateAuthDependsOnGatewayAAI(serviceName string, auth Auth, gatewayAAIEnabled bool) error {
+	if auth.Enabled && !gatewayAAIEnabled {
+		return fmt.Errorf("%s auth requires gateway aai to be enabled", serviceName)
+	}
+
+	return nil
+}
+
 // Validate checks whether the configuration contains all required values.
 func (c *Config) Validate() error {
 	// Basic required fields
@@ -154,6 +162,9 @@ func (c *Config) Validate() error {
 	if c.Components.MetadataDatabase.Enabled && c.Images.MetadataDatabaseImage == "" {
 		return fmt.Errorf("metadata database image is required when metadata database is enabled")
 	}
+	if c.Components.AAIService.Enabled && c.Images.AAIServiceImage == "" {
+		return fmt.Errorf("aai service image is required when aai service is enabled")
+	}
 
 	// Platform GUI validation
 	if c.Components.PlatformGUI.BaseURL == "" {
@@ -179,14 +190,52 @@ func (c *Config) Validate() error {
 	}
 
 	// AAI validation
-	if c.Components.Gateway.Aai.Enabled {
-		if c.Components.Gateway.Aai.ServiceEndpoint == "" {
+	if c.Components.AAIService.Enabled {
+		if !c.Components.Gateway.AAI.Enabled {
+			return fmt.Errorf("aai service is enabled but aai in the gateway is disabled")
+		}
+		if c.Components.AAIService.Name == "" {
+			return fmt.Errorf("aai service name is required when aai service is enabled")
+		}
+		if c.Components.AAIService.Surname == "" {
+			return fmt.Errorf("aai service surname is required when aai service is enabled")
+		}
+		if c.Components.AAIService.Email == "" {
+			return fmt.Errorf("aai service email is required when aai service is enabled")
+		}
+		if c.Components.AAIService.Password == "" {
+			return fmt.Errorf("aai service password is required when aai service is enabled")
+		}
+	}
+	if c.Components.Gateway.AAI.Enabled {
+		if c.Components.Gateway.AAI.ServiceEndpoint == "" {
 			return fmt.Errorf("aai service endpoint is required when aai is enabled")
+		}
+	}
+
+	authValidations := []struct {
+		serviceName string
+		auth        Auth
+	}{
+		{serviceName: "backoffice service", auth: c.Components.Backoffice.Service.Auth},
+		{serviceName: "converter service", auth: c.Components.Converter.Auth},
+		{serviceName: "resources service", auth: c.Components.ResourcesService.Auth},
+		{serviceName: "ingestor service", auth: c.Components.IngestorService.Auth},
+		{serviceName: "external access service", auth: c.Components.ExternalAccessService.Auth},
+		{serviceName: "sharing service", auth: c.Components.SharingService.Auth},
+		{serviceName: "email sender service", auth: c.Components.EmailSenderService.Auth},
+	}
+	for _, validation := range authValidations {
+		if err := validateAuthDependsOnGatewayAAI(validation.serviceName, validation.auth, c.Components.Gateway.AAI.Enabled); err != nil {
+			return err
 		}
 	}
 
 	// Backoffice validation
 	if c.Components.Backoffice.Enabled {
+		if !c.Components.Backoffice.Service.Auth.Enabled {
+			return fmt.Errorf("backoffice service auth must be enabled when backoffice is enabled")
+		}
 		if c.Components.Backoffice.GUI.BaseURL == "" {
 			return fmt.Errorf("backoffice base url is required when backoffice is enabled")
 		}

--- a/pkg/k8s/config/config_validate_test.go
+++ b/pkg/k8s/config/config_validate_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 )
 
+const externalAAIUserinfoEndpoint = "https://auth.example.com/oauth2/userinfo"
+
 func TestConfigValidate_Requirements(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -246,7 +248,7 @@ func TestConfigValidate_AAI(t *testing.T) {
 func TestConfigValidate_GatewayAAIWithExternalEndpointIsValid(t *testing.T) {
 	cfg := GetDefaultConfig()
 	cfg.Components.Gateway.AAI.Enabled = true
-	cfg.Components.Gateway.AAI.ServiceEndpoint = "https://auth.example.com/oauth2/userinfo"
+	cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIUserinfoEndpoint
 	cfg.Components.AAIService.Enabled = false
 
 	if err := cfg.Validate(); err != nil {
@@ -346,7 +348,7 @@ func TestConfigValidate_ServiceAuthRequiresGatewayAAI(t *testing.T) {
 func TestConfigValidate_ServiceAuthIsValidWithGatewayAAI(t *testing.T) {
 	cfg := GetDefaultConfig()
 	cfg.Components.Gateway.AAI.Enabled = true
-	cfg.Components.Gateway.AAI.ServiceEndpoint = "https://auth.example.com/oauth2/userinfo"
+	cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIUserinfoEndpoint
 	cfg.Components.ResourcesService.Auth.Enabled = true
 
 	if err := cfg.Validate(); err != nil {

--- a/pkg/k8s/config/config_validate_test.go
+++ b/pkg/k8s/config/config_validate_test.go
@@ -90,7 +90,7 @@ func TestConfigValidate_Requirements(t *testing.T) {
 			name: "aai service endpoint is required when aai is enabled",
 			mutate: func(cfg *Config) {
 				enableAAI(cfg)
-				cfg.Components.Gateway.Aai.ServiceEndpoint = ""
+				cfg.Components.Gateway.AAI.ServiceEndpoint = ""
 			},
 			wantErr:     true,
 			errContains: "aai service endpoint is required when aai is enabled",
@@ -166,9 +166,197 @@ func TestConfigValidate_DefaultConfigIsValid(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_AAI(t *testing.T) {
+	tests := []struct {
+		name        string
+		mutate      func(cfg *Config)
+		errContains string
+	}{
+		{
+			name: "aai service requires gateway aai",
+			mutate: func(cfg *Config) {
+				cfg.Components.AAIService.Enabled = true
+			},
+			errContains: "aai service is enabled but aai in the gateway is disabled",
+		},
+		{
+			name: "aai service name is required when enabled",
+			mutate: func(cfg *Config) {
+				enableAAI(cfg)
+				cfg.Components.AAIService.Enabled = true
+				cfg.Components.AAIService.Name = ""
+			},
+			errContains: "aai service name is required when aai service is enabled",
+		},
+		{
+			name: "aai service surname is required when enabled",
+			mutate: func(cfg *Config) {
+				enableAAI(cfg)
+				cfg.Components.AAIService.Enabled = true
+				cfg.Components.AAIService.Surname = ""
+			},
+			errContains: "aai service surname is required when aai service is enabled",
+		},
+		{
+			name: "aai service email is required when enabled",
+			mutate: func(cfg *Config) {
+				enableAAI(cfg)
+				cfg.Components.AAIService.Enabled = true
+				cfg.Components.AAIService.Email = ""
+			},
+			errContains: "aai service email is required when aai service is enabled",
+		},
+		{
+			name: "aai service password is required when enabled",
+			mutate: func(cfg *Config) {
+				enableAAI(cfg)
+				cfg.Components.AAIService.Enabled = true
+				cfg.Components.AAIService.Password = ""
+			},
+			errContains: "aai service password is required when aai service is enabled",
+		},
+		{
+			name: "aai service image is required when enabled",
+			mutate: func(cfg *Config) {
+				enableAAI(cfg)
+				cfg.Components.AAIService.Enabled = true
+				cfg.Images.AAIServiceImage = ""
+			},
+			errContains: "aai service image is required when aai service is enabled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := GetDefaultConfig()
+			tt.mutate(cfg)
+
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("Validate() error = nil, want error containing %q", tt.errContains)
+			}
+
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("Validate() error = %q, want substring %q", err.Error(), tt.errContains)
+			}
+		})
+	}
+}
+
+func TestConfigValidate_GatewayAAIWithExternalEndpointIsValid(t *testing.T) {
+	cfg := GetDefaultConfig()
+	cfg.Components.Gateway.AAI.Enabled = true
+	cfg.Components.Gateway.AAI.ServiceEndpoint = "https://auth.example.com/oauth2/userinfo"
+	cfg.Components.AAIService.Enabled = false
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestConfigValidate_BackofficeRequiresAuth(t *testing.T) {
+	cfg := GetDefaultConfig()
+	cfg.Components.Backoffice.Enabled = true
+	cfg.Components.Backoffice.Service.Auth.Enabled = false
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want error")
+	}
+
+	if !strings.Contains(err.Error(), "backoffice service auth must be enabled when backoffice is enabled") {
+		t.Fatalf("Validate() error = %q, want substring %q", err.Error(), "backoffice service auth must be enabled when backoffice is enabled")
+	}
+}
+
+func TestConfigValidate_ServiceAuthRequiresGatewayAAI(t *testing.T) {
+	tests := []struct {
+		name        string
+		mutate      func(cfg *Config)
+		errContains string
+	}{
+		{
+			name: "backoffice service auth requires gateway aai",
+			mutate: func(cfg *Config) {
+				cfg.Components.Backoffice.Service.Auth.Enabled = true
+			},
+			errContains: "backoffice service auth requires gateway aai to be enabled",
+		},
+		{
+			name: "converter service auth requires gateway aai",
+			mutate: func(cfg *Config) {
+				cfg.Components.Converter.Auth.Enabled = true
+			},
+			errContains: "converter service auth requires gateway aai to be enabled",
+		},
+		{
+			name: "resources service auth requires gateway aai",
+			mutate: func(cfg *Config) {
+				cfg.Components.ResourcesService.Auth.Enabled = true
+			},
+			errContains: "resources service auth requires gateway aai to be enabled",
+		},
+		{
+			name: "ingestor service auth requires gateway aai",
+			mutate: func(cfg *Config) {
+				cfg.Components.IngestorService.Auth.Enabled = true
+			},
+			errContains: "ingestor service auth requires gateway aai to be enabled",
+		},
+		{
+			name: "external access service auth requires gateway aai",
+			mutate: func(cfg *Config) {
+				cfg.Components.ExternalAccessService.Auth.Enabled = true
+			},
+			errContains: "external access service auth requires gateway aai to be enabled",
+		},
+		{
+			name: "sharing service auth requires gateway aai",
+			mutate: func(cfg *Config) {
+				cfg.Components.SharingService.Auth.Enabled = true
+			},
+			errContains: "sharing service auth requires gateway aai to be enabled",
+		},
+		{
+			name: "email sender service auth requires gateway aai",
+			mutate: func(cfg *Config) {
+				cfg.Components.EmailSenderService.Auth.Enabled = true
+			},
+			errContains: "email sender service auth requires gateway aai to be enabled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := GetDefaultConfig()
+			tt.mutate(cfg)
+
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("Validate() error = nil, want error containing %q", tt.errContains)
+			}
+
+			if !strings.Contains(err.Error(), tt.errContains) {
+				t.Fatalf("Validate() error = %q, want substring %q", err.Error(), tt.errContains)
+			}
+		})
+	}
+}
+
+func TestConfigValidate_ServiceAuthIsValidWithGatewayAAI(t *testing.T) {
+	cfg := GetDefaultConfig()
+	cfg.Components.Gateway.AAI.Enabled = true
+	cfg.Components.Gateway.AAI.ServiceEndpoint = "https://auth.example.com/oauth2/userinfo"
+	cfg.Components.ResourcesService.Auth.Enabled = true
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}
+
 func enableAAI(cfg *Config) {
-	cfg.Components.Gateway.Aai.Enabled = true
-	cfg.Components.Gateway.Aai.ServiceEndpoint = "https://aai.example.com"
+	cfg.Components.Gateway.AAI.Enabled = true
+	cfg.Components.Gateway.AAI.ServiceEndpoint = "https://aai.example.com"
 }
 
 func enableMonitoring(cfg *Config) {

--- a/pkg/k8s/config/helm/templates/aai-service.yaml
+++ b/pkg/k8s/config/helm/templates/aai-service.yaml
@@ -8,11 +8,7 @@ INITIAL_ADMIN_NAME: {{ .Values.components.aai_service.name | quote }}
 INITIAL_ADMIN_SURNAME: {{ .Values.components.aai_service.surname | quote }}
 INITIAL_ADMIN_EMAIL: {{ .Values.components.aai_service.email | quote }}
 INITIAL_ADMIN_PASSWORD: {{ .Values.components.aai_service.password | quote }}
-{{- if .Values.url_prefix_namespace }}
-APP_CORS_ALLOW_ORIGIN: {{ printf "%s://%s/%s%s" .Values.protocol .Values.domain .Release.Namespace .Values.components.backoffice.gui.base_url | quote }}
-{{- else }}
-APP_CORS_ALLOW_ORIGIN: {{ printf "%s://%s%s" .Values.protocol .Values.domain .Values.components.backoffice.gui.base_url | quote }}
-{{- end }}
+APP_CORS_ALLOW_ORIGIN: "*"
 {{- end -}}
 
 {{- if .Values.components.aai_service.enabled }}
@@ -74,6 +70,40 @@ spec:
   selector:
     {{- include "epos.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: aai-service
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: aai-service
+  labels:
+    {{- include "epos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: aai-service
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: {{ .Values.domain }}
+    http:
+      paths:
+      {{- if .Values.url_prefix_namespace }}
+      - path: /{{ .Release.Namespace }}/aai(/|$)(.*)
+      {{- else }}
+      - path: /aai(/|$)(.*)
+      {{- end }}
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: aai-service
+            port:
+              number: 8080
+  {{- if .Values.tls.enabled }}
+  tls:
+  - hosts:
+    - {{ .Values.domain }}
+    secretName: {{ .Values.tls.secret_name }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/pkg/k8s/config/helm/templates/aai-service.yaml
+++ b/pkg/k8s/config/helm/templates/aai-service.yaml
@@ -1,0 +1,87 @@
+{{- define "epos.aaiServiceConfigData" -}}
+{{- if eq .Values.protocol "https" }}
+APP_SECURE_COOKIES: "true"
+{{- else }}
+APP_SECURE_COOKIES: "false"
+{{- end }}
+INITIAL_ADMIN_NAME: {{ .Values.components.aai_service.name | quote }}
+INITIAL_ADMIN_SURNAME: {{ .Values.components.aai_service.surname | quote }}
+INITIAL_ADMIN_EMAIL: {{ .Values.components.aai_service.email | quote }}
+INITIAL_ADMIN_PASSWORD: {{ .Values.components.aai_service.password | quote }}
+{{- if .Values.url_prefix_namespace }}
+APP_CORS_ALLOW_ORIGIN: {{ printf "%s://%s/%s%s" .Values.protocol .Values.domain .Release.Namespace .Values.components.backoffice.gui.base_url | quote }}
+{{- else }}
+APP_CORS_ALLOW_ORIGIN: {{ printf "%s://%s%s" .Values.protocol .Values.domain .Values.components.backoffice.gui.base_url | quote }}
+{{- end }}
+{{- end -}}
+
+{{- if .Values.components.aai_service.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aai-service
+  labels:
+    {{- include "epos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: aai-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "epos.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: aai-service
+  template:
+    metadata:
+      labels:
+        {{- include "epos.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: aai-service
+      annotations:
+        checksum/aai-service-config: {{ include "epos.aaiServiceConfigData" . | sha256sum }}
+    spec:
+      {{- include "epos.image_pull_secrets" . | nindent 6 }}
+      containers:
+      - name: aai-service
+        image: {{ .Values.images.aai_service_image }}
+        ports:
+        - containerPort: 8080
+          name: http
+        envFrom:
+        - configMapRef:
+            name: aai-service
+        volumeMounts:
+        - name: aai
+          mountPath: /app/data
+      volumes:
+      - name: aai
+        persistentVolumeClaim:
+          claimName: aai
+      {{- include "epos.nodeSelector" . | nindent 6 }}
+      {{- include "epos.tolerations" . | nindent 6 }}
+      {{- include "epos.affinity" . | nindent 6 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: aai-service
+  labels:
+    {{- include "epos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: aai-service
+spec:
+  ports:
+  - port: 8080
+    targetPort: 8080
+    name: http
+  selector:
+    {{- include "epos.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: aai-service
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aai-service
+  labels:
+    {{- include "epos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: aai-service
+data:
+  {{- include "epos.aaiServiceConfigData" . | nindent 2 }}
+{{- end }}

--- a/pkg/k8s/config/helm/templates/backoffice-ui.yaml
+++ b/pkg/k8s/config/helm/templates/backoffice-ui.yaml
@@ -5,6 +5,11 @@ BASE_URL: /{{ .Release.Namespace }}{{ .Values.components.backoffice.gui.base_url
 BASE_URL: {{ .Values.components.backoffice.gui.base_url }}
 {{- end }}
 API_HOST: http://gateway:5000/api
+{{- if .Values.url_prefix_namespace }}
+AUTH_ROOT_URL: {{ printf "%s://%s/%s/aai" .Values.protocol .Values.domain .Release.Namespace | quote }}
+{{- else }}
+AUTH_ROOT_URL: {{ printf "%s://%s/aai" .Values.protocol .Values.domain | quote }}
+{{- end }}
 {{- end -}}
 
 {{- if .Values.components.backoffice.enabled }}

--- a/pkg/k8s/config/helm/templates/dataportal.yaml
+++ b/pkg/k8s/config/helm/templates/dataportal.yaml
@@ -5,6 +5,11 @@ BASE_URL: /{{ .Release.Namespace }}{{ .Values.components.platform_gui.base_url }
 BASE_URL: {{ .Values.components.platform_gui.base_url }}
 {{- end }}
 API_HOST: http://gateway:5000/api
+{{- if .Values.url_prefix_namespace }}
+AUTH_ROOT_URL: {{ printf "%s://%s/%s/aai" .Values.protocol .Values.domain .Release.Namespace | quote }}
+{{- else }}
+AUTH_ROOT_URL: {{ printf "%s://%s/aai" .Values.protocol .Values.domain | quote }}
+{{- end }}
 {{- end -}}
 
 ---

--- a/pkg/k8s/config/helm/templates/gateway.yaml
+++ b/pkg/k8s/config/helm/templates/gateway.yaml
@@ -67,6 +67,9 @@ spec:
       {{- if .Values.components.backoffice.enabled }}
       {{- include "epos.waitForServiceInitContainer" (dict "name" "backoffice-service" "port" 8080) | nindent 6 }}
       {{- end }}
+      {{- if .Values.components.aai_service.enabled }}
+      {{- include "epos.waitForServiceInitContainer" (dict "name" "aai-service" "port" 8080) | nindent 6 }}
+      {{- end }}
       containers:
       - name: gateway
         image: {{ .Values.images.gateway_image }}

--- a/pkg/k8s/config/helm/templates/pvc.yaml
+++ b/pkg/k8s/config/helm/templates/pvc.yaml
@@ -29,3 +29,19 @@ spec:
     requests:
       storage: 5Gi
 {{- end }}
+{{- if .Values.components.aai_service.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: aai
+  labels:
+    {{- include "epos.labels" . | nindent 4 }}
+    app.kubernetes.io/component: aai-service
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+{{- end }}

--- a/pkg/k8s/config/helm/values.yaml
+++ b/pkg/k8s/config/helm/values.yaml
@@ -21,10 +21,13 @@ components:
 
   gateway:
     aai:
-      # Enable/disable AAI (Authentication and Authorization Infrastructure) integration
+      # Enable/disable AAI (Authentication and Authorization Infrastructure) integration in the gateway.
+      # When enabled, the gateway will call the configured userinfo endpoint to validate authenticated requests.
+      # This can point to the embedded aai_service below or to an external provider.
       enabled: false
-      # AAI service endpoint URL (required when AAI is enabled)
-      service_endpoint: ""
+      # Userinfo endpoint used by the gateway when AAI is enabled.
+      # Use the embedded service default below for local auth, or replace it with an external provider endpoint.
+      service_endpoint: "http://aai-service:8080/oauth2/userinfo"
 
     # Base URL path for the API gateway. Must start with / and end with /api/v1
     base_url: "/api/v1/" # it needs to end with /api/v1
@@ -164,6 +167,17 @@ components:
     # API key for authenticating with the email service
     mail_api_key: "changeme"
 
+  aai_service:
+    # Enable/disable the embedded local AAI service container.
+    # This is optional: the gateway can use an external AAI provider with this disabled.
+    # If you enable this service, gateway.aai.enabled must also be enabled.
+    enabled: false
+    # Initial admin user seeded into the embedded AAI service on first startup
+    name: "EPOS"
+    surname: "User"
+    email: "epos@epos.eu"
+    password: "epos"
+
 jobs:
   # When false, no job will run.
   enabled: false
@@ -227,3 +241,4 @@ images:
   backoffice_ui_image:        "ghcr.io/epos-eric/epos-backoffice-gui:latest"
   email_sender_service_image: "ghcr.io/epos-eric/email-sender-service:latest"
   sharing_service_image:      "ghcr.io/epos-eric/sharing-service:latest"
+  aai_service_image:          "ghcr.io/epos-eric/oss-aai-service:latest"

--- a/pkg/k8s/config/model.go
+++ b/pkg/k8s/config/model.go
@@ -27,8 +27,8 @@ type PlatformGUI struct {
 	BaseURL string `yaml:"base_url"`
 }
 
-// Aai configures AAI integration for gateway services.
-type Aai struct {
+// AAI configures AAI integration for gateway services.
+type AAI struct {
 	Enabled         bool   `yaml:"enabled"`
 	ServiceEndpoint string `yaml:"service_endpoint"`
 }
@@ -42,7 +42,7 @@ type SwaggerPage struct {
 
 // Gateway configures gateway URLs and auth integrations.
 type Gateway struct {
-	Aai         Aai         `yaml:"aai"`
+	AAI         AAI         `yaml:"aai"`
 	BaseURL     string      `yaml:"base_url"`
 	SwaggerPage SwaggerPage `yaml:"swagger_page"`
 }
@@ -145,6 +145,15 @@ type EmailSenderService struct {
 	MailAPIKey      string `yaml:"mail_api_key"`
 }
 
+// AAIService configures the embedded AAI service.
+type AAIService struct {
+	Enabled  bool   `yaml:"enabled"`
+	Name     string `yaml:"name"`
+	Surname  string `yaml:"surname"`
+	Email    string `yaml:"email"`
+	Password string `yaml:"password"`
+}
+
 // InitDBJob configures the init-db Kubernetes job.
 type InitDBJob struct {
 	Enabled               bool   `yaml:"enabled"`
@@ -183,6 +192,7 @@ type Components struct {
 	Rabbitmq              Rabbitmq              `yaml:"rabbitmq"`
 	MetadataDatabase      MetadataDatabase      `yaml:"metadata_database"`
 	EmailSenderService    EmailSenderService    `yaml:"email_sender_service"`
+	AAIService            AAIService            `yaml:"aai_service"`
 }
 
 // Monitoring configures optional monitoring integration.

--- a/pkg/k8s/config/render_test.go
+++ b/pkg/k8s/config/render_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/EPOS-ERIC/epos-opensource/pkg/k8s/config"
 )
 
+const externalAAIUserinfoEndpoint = "https://auth.example.com/oauth2/userinfo"
+
 func TestConfigRender(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -136,12 +138,12 @@ func TestConfigRender(t *testing.T) {
 			mutate: func(cfg *config.Config) {
 				cfg.Name = "test-external-aai"
 				cfg.Components.Gateway.AAI.Enabled = true
-				cfg.Components.Gateway.AAI.ServiceEndpoint = "https://auth.example.com/oauth2/userinfo"
+				cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIUserinfoEndpoint
 			},
 			wantContains: map[string][]string{
 				"templates/gateway.yaml": {
 					`IS_AAI_ENABLED: "true"`,
-					`AAI_SERVICE_ENDPOINT: "https://auth.example.com/oauth2/userinfo"`,
+					`AAI_SERVICE_ENDPOINT: "` + externalAAIUserinfoEndpoint + `"`,
 				},
 			},
 			notContains: map[string][]string{

--- a/pkg/k8s/config/render_test.go
+++ b/pkg/k8s/config/render_test.go
@@ -48,6 +48,7 @@ func TestConfigRender(t *testing.T) {
 					"MONITORING_USER:",
 					"MONITORING_PWD:",
 				},
+				"templates/aai-service.yaml":          {"name: aai-service"},
 				"templates/backoffice-service.yaml":   {"name: backoffice-service"},
 				"templates/backoffice-ui.yaml":        {"name: backoffice-ui"},
 				"templates/converter-service.yaml":    {"name: converter-service"},
@@ -104,6 +105,49 @@ func TestConfigRender(t *testing.T) {
 			wantContains: map[string][]string{
 				"templates/gateway.yaml":              {`LOAD_EMAIL_SENDER_API: "true:true"`},
 				"templates/email-sender-service.yaml": {"name: email-sender-service"},
+			},
+		},
+		{
+			name: "embedded aai enabled renders manifest and gateway settings",
+			mutate: func(cfg *config.Config) {
+				cfg.Name = "test-aai"
+				cfg.Components.Gateway.AAI.Enabled = true
+				cfg.Components.AAIService.Enabled = true
+			},
+			wantContains: map[string][]string{
+				"templates/gateway.yaml": {
+					`IS_AAI_ENABLED: "true"`,
+					`AAI_SERVICE_ENDPOINT: "http://aai-service:8080/oauth2/userinfo"`,
+					"wait-for-aai-service",
+				},
+				"templates/aai-service.yaml": {
+					"name: aai-service",
+					`INITIAL_ADMIN_NAME: "EPOS"`,
+					`INITIAL_ADMIN_SURNAME: "User"`,
+					`INITIAL_ADMIN_EMAIL: "epos@epos.eu"`,
+					`INITIAL_ADMIN_PASSWORD: "epos"`,
+					`APP_CORS_ALLOW_ORIGIN: "http://localhost/test-aai/backoffice/"`,
+				},
+				"templates/pvc.yaml": {"name: aai"},
+			},
+		},
+		{
+			name: "embedded aai disabled supports external endpoint without manifest",
+			mutate: func(cfg *config.Config) {
+				cfg.Name = "test-external-aai"
+				cfg.Components.Gateway.AAI.Enabled = true
+				cfg.Components.Gateway.AAI.ServiceEndpoint = "https://auth.example.com/oauth2/userinfo"
+			},
+			wantContains: map[string][]string{
+				"templates/gateway.yaml": {
+					`IS_AAI_ENABLED: "true"`,
+					`AAI_SERVICE_ENDPOINT: "https://auth.example.com/oauth2/userinfo"`,
+				},
+			},
+			notContains: map[string][]string{
+				"templates/gateway.yaml":     {"wait-for-aai-service"},
+				"templates/aai-service.yaml": {"name: aai-service"},
+				"templates/pvc.yaml":         {"name: aai"},
 			},
 		},
 		{

--- a/pkg/k8s/config/render_test.go
+++ b/pkg/k8s/config/render_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/EPOS-ERIC/epos-opensource/pkg/k8s/config"
 )
 
-const externalAAIUserinfoEndpoint = "https://auth.example.com/oauth2/userinfo"
+const (
+	externalAAIUserinfoEndpoint = "https://auth.example.com/oauth2/userinfo"
+)
 
 func TestConfigRender(t *testing.T) {
 	tests := []struct {
@@ -31,7 +33,7 @@ func TestConfigRender(t *testing.T) {
 				"templates/resources-service.yaml",
 			},
 			wantContains: map[string][]string{
-				"templates/dataportal.yaml":        {"name: dataportal"},
+				"templates/dataportal.yaml":        {"name: dataportal", `AUTH_ROOT_URL: "http://localhost/test-default/aai"`},
 				"templates/gateway.yaml":           {"name: gateway", `IS_AAI_ENABLED: "false"`},
 				"templates/rabbitmq.yaml":          {"name: rabbitmq"},
 				"templates/metadata-database.yaml": {"name: metadata-database"},
@@ -68,7 +70,7 @@ func TestConfigRender(t *testing.T) {
 			wantContains: map[string][]string{
 				"templates/gateway.yaml":            {`LOAD_BACKOFFICE_API: "false:false"`},
 				"templates/backoffice-service.yaml": {"name: backoffice-service"},
-				"templates/backoffice-ui.yaml":      {"name: backoffice-ui"},
+				"templates/backoffice-ui.yaml":      {"name: backoffice-ui", `AUTH_ROOT_URL: "http://localhost/test-backoffice/aai"`},
 			},
 		},
 		{
@@ -124,11 +126,13 @@ func TestConfigRender(t *testing.T) {
 				},
 				"templates/aai-service.yaml": {
 					"name: aai-service",
+					"kind: Ingress",
+					"path: /test-aai/aai(/|$)(.*)",
 					`INITIAL_ADMIN_NAME: "EPOS"`,
 					`INITIAL_ADMIN_SURNAME: "User"`,
 					`INITIAL_ADMIN_EMAIL: "epos@epos.eu"`,
 					`INITIAL_ADMIN_PASSWORD: "epos"`,
-					`APP_CORS_ALLOW_ORIGIN: "http://localhost/test-aai/backoffice/"`,
+					`APP_CORS_ALLOW_ORIGIN: "*"`,
 				},
 				"templates/pvc.yaml": {"name: aai"},
 			},


### PR DESCRIPTION
## Summary

Add embedded AAI service support to both Docker and Kubernetes configurations and rendered deployments. This wires the new service into the generated manifests, adds validation for AAI and service auth dependencies, and updates the default config docs so gateway auth can use either the embedded service or an external endpoint.

## How to Test

1. Run `make build`.
2. Run `go test ./pkg/docker/config ./pkg/docker ./pkg/k8s/config ./pkg/k8s`.
3. Export the default configs:
   - `epos-opensource docker export ./out/docker`
   - `epos-opensource k8s export ./out/k8s`
4. In both exported configs, set:
   - `components.gateway.aai.enabled: true`
   - `components.aai_service.enabled: true`
5. Render both environments:
   - `epos-opensource docker render test-aai -c ./out/docker/docker-config.yaml -o ./rendered/docker`
   - `epos-opensource k8s render test-aai -c ./out/k8s/k8s-config.yaml -o ./rendered/k8s`
6. Verify the rendered output includes the embedded `aai-service` and the expected AAI env/config values.
7. Verify validation fails if any service auth is enabled while `components.gateway.aai.enabled` is `false`.
8. Verify external AAI mode still works by keeping `components.aai_service.enabled: false` and setting `components.gateway.aai.service_endpoint` to an external userinfo endpoint.

---

## Checklist (Required)

- [x] Builds locally with no errors (`make build`).
- [x] Linter passes (`make lint`) and tests pass (`make test`).
- [x] No secrets/keys/tokens added.
- [x] CLI behavior and flags remain backward compatible **or** breaking changes are documented here.

## Checklist (Recommended)

- [x] Docs/help/examples updated if behavior/flags changed.
- [x] Edge cases considered (empty inputs, timeouts, invalid paths).

---

Blocked by:
- https://github.com/EPOS-ERIC/epos-backoffice-gui/pull/12
- https://github.com/EPOS-ERIC/epos-gui/pull/64
- https://github.com/EPOS-ERIC/oss-aai-service/pull/1
