### PR TITLE
feat(k8s): add ingress config per service

### DIFF
--- a/pkg/k8s/config/config.go
+++ b/pkg/k8s/config/config.go
@@ -125,6 +125,14 @@ func validateAuthDependsOnGatewayAAI(serviceName string, auth Auth, gatewayAAIEn
 	return nil
 }
 
+func validateIngressTLSSecret(serviceName string, tls TLS) error {
+	if tls.Enabled && tls.SecretName == "" {
+		return fmt.Errorf("%s tls secret_name is required when tls is enabled", serviceName)
+	}
+
+	return nil
+}
+
 // Validate checks whether the configuration contains all required values.
 func (c *Config) Validate() error {
 	// Basic required fields
@@ -134,9 +142,20 @@ func (c *Config) Validate() error {
 	if c.Protocol != "http" && c.Protocol != "https" {
 		return fmt.Errorf("protocol must be http or https")
 	}
-	if c.TLS.Enabled {
-		if c.TLS.SecretName == "" {
-			return fmt.Errorf("tls secret_name is required when tls is enabled")
+	if err := validateIngressTLSSecret("platform gui", c.Components.PlatformGUI.TLS); err != nil {
+		return err
+	}
+	if err := validateIngressTLSSecret("gateway", c.Components.Gateway.TLS); err != nil {
+		return err
+	}
+	if c.Components.Backoffice.Enabled {
+		if err := validateIngressTLSSecret("backoffice", c.Components.Backoffice.TLS); err != nil {
+			return err
+		}
+	}
+	if c.Components.AAIService.Enabled {
+		if err := validateIngressTLSSecret("aai service", c.Components.AAIService.TLS); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/k8s/config/config_validate_test.go
+++ b/pkg/k8s/config/config_validate_test.go
@@ -89,6 +89,50 @@ func TestConfigValidate_Requirements(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "create namespace can be disabled",
+			mutate: func(cfg *Config) {
+				cfg.CreateNamespace = false
+			},
+			wantErr: false,
+		},
+		{
+			name: "platform gui tls secret_name required when tls enabled",
+			mutate: func(cfg *Config) {
+				cfg.Components.PlatformGUI.TLS.Enabled = true
+			},
+			wantErr:     true,
+			errContains: "platform gui tls secret_name is required when tls is enabled",
+		},
+		{
+			name: "gateway tls secret_name required when tls enabled",
+			mutate: func(cfg *Config) {
+				cfg.Components.Gateway.TLS.Enabled = true
+			},
+			wantErr:     true,
+			errContains: "gateway tls secret_name is required when tls is enabled",
+		},
+		{
+			name: "backoffice tls secret_name required when backoffice and tls enabled",
+			mutate: func(cfg *Config) {
+				cfg.Components.Backoffice.Enabled = true
+				cfg.Components.Backoffice.Service.Auth.Enabled = true
+				cfg.Components.Backoffice.TLS.Enabled = true
+				cfg.Components.Gateway.AAI.Enabled = true
+			},
+			wantErr:     true,
+			errContains: "backoffice tls secret_name is required when tls is enabled",
+		},
+		{
+			name: "aai service tls secret_name required when aai service and tls enabled",
+			mutate: func(cfg *Config) {
+				enableAAI(cfg)
+				cfg.Components.AAIService.Enabled = true
+				cfg.Components.AAIService.TLS.Enabled = true
+			},
+			wantErr:     true,
+			errContains: "aai service tls secret_name is required when tls is enabled",
+		},
+		{
 			name: "aai service endpoint is required when aai is enabled",
 			mutate: func(cfg *Config) {
 				enableAAI(cfg)
@@ -165,6 +209,22 @@ func TestConfigValidate_DefaultConfigIsValid(t *testing.T) {
 
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestConfigValidate_DefaultCreateNamespaceEnabled(t *testing.T) {
+	cfg := GetDefaultConfig()
+
+	if !cfg.CreateNamespace {
+		t.Fatal("GetDefaultConfig().CreateNamespace = false, want true")
+	}
+}
+
+func TestConfigValidate_DefaultCertManagerIssuerConfigured(t *testing.T) {
+	cfg := GetDefaultConfig()
+
+	if cfg.CertManagerIssuer == "" {
+		t.Fatal("GetDefaultConfig().CertManagerIssuer = empty, want non-empty")
 	}
 }
 

--- a/pkg/k8s/config/helm/templates/aai-service.yaml
+++ b/pkg/k8s/config/helm/templates/aai-service.yaml
@@ -81,6 +81,10 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
+
+    {{- if and .Values.components.aai_service.tls.enabled .Values.cert_manager_issuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.cert_manager_issuer }}
+    {{- end }}
 spec:
   ingressClassName: nginx
   rules:
@@ -98,11 +102,11 @@ spec:
             name: aai-service
             port:
               number: 8080
-  {{- if .Values.tls.enabled }}
+  {{- if .Values.components.aai_service.tls.enabled }}
   tls:
   - hosts:
     - {{ .Values.domain }}
-    secretName: {{ .Values.tls.secret_name }}
+    secretName: {{ .Values.components.aai_service.tls.secret_name }}
   {{- end }}
 ---
 apiVersion: v1

--- a/pkg/k8s/config/helm/templates/backoffice-ui.yaml
+++ b/pkg/k8s/config/helm/templates/backoffice-ui.yaml
@@ -82,6 +82,10 @@ metadata:
     {{- else }}
     nginx.ingress.kubernetes.io/rewrite-target: {{ .Values.components.backoffice.gui.base_url }}
     {{- end }}
+
+    {{- if and .Values.components.backoffice.tls.enabled .Values.cert_manager_issuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.cert_manager_issuer }}
+    {{- end }}
 spec:
   ingressClassName: nginx
   rules:
@@ -99,11 +103,11 @@ spec:
             name: backoffice-ui
             port:
               number: 80
-  {{- if .Values.tls.enabled }}
+  {{- if .Values.components.backoffice.tls.enabled }}
   tls:
   - hosts:
     - {{ .Values.domain }}
-    secretName: {{ .Values.tls.secret_name }}
+    secretName: {{ .Values.components.backoffice.tls.secret_name }}
   {{- end }}
 ---
 apiVersion: v1

--- a/pkg/k8s/config/helm/templates/dataportal.yaml
+++ b/pkg/k8s/config/helm/templates/dataportal.yaml
@@ -79,6 +79,10 @@ metadata:
     {{- else }}
     nginx.ingress.kubernetes.io/rewrite-target: {{ .Values.components.platform_gui.base_url }}
     {{- end }}
+
+    {{- if and .Values.components.platform_gui.tls.enabled .Values.cert_manager_issuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.cert_manager_issuer }}
+    {{- end }}
 spec:
   ingressClassName: nginx
   rules:
@@ -96,11 +100,11 @@ spec:
             name: dataportal
             port:
               number: 80
-  {{- if .Values.tls.enabled }}
+  {{- if .Values.components.platform_gui.tls.enabled }}
   tls:
   - hosts:
     - {{ .Values.domain }}
-    secretName: {{ .Values.tls.secret_name }}
+    secretName: {{ .Values.components.platform_gui.tls.secret_name }}
   {{- end }}
 ---
 apiVersion: v1

--- a/pkg/k8s/config/helm/templates/gateway.yaml
+++ b/pkg/k8s/config/helm/templates/gateway.yaml
@@ -142,6 +142,10 @@ metadata:
     {{- else }}
     nginx.ingress.kubernetes.io/rewrite-target: {{ .Values.components.gateway.base_url }}
     {{- end }}
+
+    {{- if and .Values.components.gateway.tls.enabled .Values.cert_manager_issuer }}
+    cert-manager.io/cluster-issuer: {{ .Values.cert_manager_issuer }}
+    {{- end }}
 spec:
   ingressClassName: nginx
   rules:
@@ -159,9 +163,9 @@ spec:
             name: gateway
             port:
               number: 5000
-  {{- if .Values.tls.enabled }}
+  {{- if .Values.components.gateway.tls.enabled }}
   tls:
   - hosts:
     - {{ .Values.domain }}
-    secretName: {{ .Values.tls.secret_name }}
+    secretName: {{ .Values.components.gateway.tls.secret_name }}
   {{- end }}

--- a/pkg/k8s/config/helm/values.yaml
+++ b/pkg/k8s/config/helm/values.yaml
@@ -1,23 +1,25 @@
 # Shared hostname/IP where all services are accessible (e.g., epos.example.com)
 domain: "localhost"
 
-# Protocol for accessing services. Must be http or https. If tls is enabled it must be https
+# Protocol for accessing services. Must be http or https. If any ingress tls is enabled it must be https
 protocol: "http"
-
-# TLS configuration for ingress resources (dataportal, gateway, and backoffice-ui)
-tls:
-  # Enable TLS termination on ingresses
-  enabled: false
-  # Name of an existing Kubernetes TLS secret in the release namespace
-  secret_name: ""
 
 # prefix the generated url for the ingresses with the name of the namespace (the name of the environment)
 url_prefix_namespace: true
+
+# create the namespace to deploy in if it doesn't exist
+create_namespace: true
 
 components:
   platform_gui:
     # URL path prefix for accessing the platform GUI interface. Must end with a /
     base_url: "/"
+
+    tls:
+      # Enable TLS termination on ingress
+      enabled: false
+      # Name of an existing Kubernetes TLS secret in the release namespace
+      secret_name: ""
 
   gateway:
     aai:
@@ -40,6 +42,12 @@ components:
       # Contact email displayed in Swagger documentation
       contact_email: ""
 
+    tls:
+      # Enable TLS termination on ingress
+      enabled: false
+      # Name of an existing Kubernetes TLS secret in the release namespace
+      secret_name: ""
+
   backoffice:
     # Enable/disable the backoffice module
     enabled: false
@@ -54,6 +62,12 @@ components:
         enabled: false
         # Restrict backoffice access to admin users only
         only_admin: false
+
+    tls:
+      # Enable TLS termination on ingress
+      enabled: false
+      # Name of an existing Kubernetes TLS secret in the release namespace
+      secret_name: ""
 
   converter:
     # Enable/disable the converter service
@@ -178,6 +192,12 @@ components:
     email: "epos@epos.eu"
     password: "epos"
 
+    tls:
+      # Enable TLS termination on ingress
+      enabled: false
+      # Name of an existing Kubernetes TLS secret in the release namespace
+      secret_name: ""
+
 jobs:
   # When false, no job will run.
   enabled: false
@@ -224,6 +244,9 @@ image_pull_secrets:
   registry_username: ""
   # Password or token used to authenticate to the container registry
   registry_password: ""
+
+# cert-manager ClusterIssuer name used in ingress annotations when tls is enabled
+cert_manager_issuer: "letsencrypt"
 
 # Container images used by EPOS services and supporting components.
 # Override tags/repositories to pin versions or use private registries.

--- a/pkg/k8s/config/model.go
+++ b/pkg/k8s/config/model.go
@@ -7,12 +7,13 @@ type Config struct {
 	Name               string           `yaml:"name"`
 	Domain             string           `yaml:"domain"`
 	Protocol           string           `yaml:"protocol"`
-	TLS                TLS              `yaml:"tls"`
 	URLPrefixNamespace bool             `yaml:"url_prefix_namespace"`
+	CreateNamespace    bool             `yaml:"create_namespace"`
 	Components         Components       `yaml:"components"`
 	Jobs               Jobs             `yaml:"jobs"`
 	Monitoring         Monitoring       `yaml:"monitoring"`
 	ImagePullSecrets   ImagePullSecrets `yaml:"image_pull_secrets"`
+	CertManagerIssuer  string           `yaml:"cert_manager_issuer"`
 	Images             common.Images    `yaml:"images"`
 }
 
@@ -25,6 +26,7 @@ type TLS struct {
 // PlatformGUI configures the platform GUI endpoint.
 type PlatformGUI struct {
 	BaseURL string `yaml:"base_url"`
+	TLS     TLS    `yaml:"tls"`
 }
 
 // AAI configures AAI integration for gateway services.
@@ -45,6 +47,7 @@ type Gateway struct {
 	AAI         AAI         `yaml:"aai"`
 	BaseURL     string      `yaml:"base_url"`
 	SwaggerPage SwaggerPage `yaml:"swagger_page"`
+	TLS         TLS         `yaml:"tls"`
 }
 
 // GUI configures a generic GUI service endpoint.
@@ -68,6 +71,7 @@ type Backoffice struct {
 	Enabled bool    `yaml:"enabled"`
 	GUI     GUI     `yaml:"gui"`
 	Service Service `yaml:"service"`
+	TLS     TLS     `yaml:"tls"`
 }
 
 // SecurityContext configures optional pod security context settings.
@@ -152,6 +156,7 @@ type AAIService struct {
 	Surname  string `yaml:"surname"`
 	Email    string `yaml:"email"`
 	Password string `yaml:"password"`
+	TLS      TLS    `yaml:"tls"`
 }
 
 // InitDBJob configures the init-db Kubernetes job.
@@ -219,12 +224,6 @@ func (c *Config) String() string {
 	}
 
 	out := "name=" + c.Name + ", domain=" + c.Domain + ", protocol=" + c.Protocol
-
-	if c.TLS.Enabled {
-		out += ", tls.enabled=true"
-	} else {
-		out += ", tls.enabled=false"
-	}
 
 	if c.URLPrefixNamespace {
 		out += ", url_prefix_namespace=true"

--- a/pkg/k8s/config/render_test.go
+++ b/pkg/k8s/config/render_test.go
@@ -10,6 +10,9 @@ import (
 
 const (
 	externalAAIUserinfoEndpoint = "https://auth.example.com/oauth2/userinfo"
+	dataportalTLSSecret         = "dataportal-tls"
+	gatewayTLSSecret            = "gateway-tls"
+	certManagerIssuerAnnotation = "cert-manager.io/cluster-issuer: letsencrypt"
 )
 
 func TestConfigRender(t *testing.T) {
@@ -176,6 +179,95 @@ func TestConfigRender(t *testing.T) {
 					"MONITORING_USER: monitor-user",
 					"MONITORING_PWD: monitor-password",
 				},
+			},
+		},
+		{
+			name: "service ingress tls renders dedicated secret per ingress",
+			mutate: func(cfg *config.Config) {
+				cfg.Name = "test-ingress-tls"
+				cfg.Components.PlatformGUI.TLS.Enabled = true
+				cfg.Components.PlatformGUI.TLS.SecretName = dataportalTLSSecret
+				cfg.Components.Gateway.TLS.Enabled = true
+				cfg.Components.Gateway.TLS.SecretName = gatewayTLSSecret
+				cfg.Components.Backoffice.Enabled = true
+				cfg.Components.Backoffice.TLS.Enabled = true
+				cfg.Components.Backoffice.TLS.SecretName = "backoffice-tls"
+				cfg.Components.AAIService.Enabled = true
+				cfg.Components.AAIService.TLS.Enabled = true
+				cfg.Components.AAIService.TLS.SecretName = "aai-tls"
+			},
+			wantContains: map[string][]string{
+				"templates/dataportal.yaml": {
+					"secretName: " + dataportalTLSSecret,
+					certManagerIssuerAnnotation,
+				},
+				"templates/gateway.yaml": {
+					"secretName: " + gatewayTLSSecret,
+					certManagerIssuerAnnotation,
+				},
+				"templates/backoffice-ui.yaml": {
+					"secretName: backoffice-tls",
+					certManagerIssuerAnnotation,
+				},
+				"templates/aai-service.yaml": {
+					"secretName: aai-tls",
+					certManagerIssuerAnnotation,
+				},
+			},
+			notContains: map[string][]string{
+				"templates/dataportal.yaml":    {gatewayTLSSecret, "backoffice-tls", "aai-tls"},
+				"templates/gateway.yaml":       {dataportalTLSSecret, "backoffice-tls", "aai-tls"},
+				"templates/backoffice-ui.yaml": {dataportalTLSSecret, gatewayTLSSecret, "aai-tls"},
+				"templates/aai-service.yaml":   {dataportalTLSSecret, gatewayTLSSecret, "backoffice-tls"},
+			},
+		},
+		{
+			name: "service ingress tls disabled omits ingress tls block",
+			mutate: func(cfg *config.Config) {
+				cfg.Name = "test-ingress-tls-toggle"
+				cfg.Components.PlatformGUI.TLS.Enabled = true
+				cfg.Components.PlatformGUI.TLS.SecretName = dataportalTLSSecret
+				cfg.Components.Gateway.TLS.Enabled = false
+				cfg.Components.Gateway.TLS.SecretName = gatewayTLSSecret
+			},
+			wantContains: map[string][]string{
+				"templates/dataportal.yaml": {
+					"secretName: " + dataportalTLSSecret,
+					certManagerIssuerAnnotation,
+				},
+			},
+			notContains: map[string][]string{
+				"templates/gateway.yaml": {"secretName:", "cert-manager.io/cluster-issuer:"},
+			},
+		},
+		{
+			name: "gateway cert manager annotation does not depend on aai tls",
+			mutate: func(cfg *config.Config) {
+				cfg.Name = "test-gateway-cert-issuer"
+				cfg.Components.Gateway.TLS.Enabled = true
+				cfg.Components.Gateway.TLS.SecretName = gatewayTLSSecret
+				cfg.Components.AAIService.TLS.Enabled = false
+			},
+			wantContains: map[string][]string{
+				"templates/gateway.yaml": {
+					"secretName: " + gatewayTLSSecret,
+					certManagerIssuerAnnotation,
+				},
+			},
+		},
+		{
+			name: "cert manager annotation omitted when issuer is empty",
+			mutate: func(cfg *config.Config) {
+				cfg.Name = "test-empty-cert-issuer"
+				cfg.CertManagerIssuer = ""
+				cfg.Components.PlatformGUI.TLS.Enabled = true
+				cfg.Components.PlatformGUI.TLS.SecretName = dataportalTLSSecret
+			},
+			wantContains: map[string][]string{
+				"templates/dataportal.yaml": {"secretName: " + dataportalTLSSecret},
+			},
+			notContains: map[string][]string{
+				"templates/dataportal.yaml": {"cert-manager.io/cluster-issuer:"},
 			},
 		},
 	}

--- a/pkg/k8s/deploy.go
+++ b/pkg/k8s/deploy.go
@@ -73,7 +73,7 @@ func Deploy(opts DeployOpts) (*Env, error) {
 	client := action.NewInstall(actionConfig)
 	client.ReleaseName = opts.Config.Name
 	client.Namespace = opts.Config.Name
-	client.CreateNamespace = true
+	client.CreateNamespace = opts.Config.CreateNamespace
 	client.Wait = true
 	client.WaitForJobs = true
 	client.Atomic = true


### PR DESCRIPTION
## Summary

Refactors K8s config to manage TLS per ingress service instead of a single top-level TLS block, so each ingress can use its own TLS secret.  
Adds `create_namespace` deploy control and wires `cert_manager_issuer` to ingress annotations when that ingress has TLS enabled.  
This supports mixed ingress TLS setups and cert-manager integration with clearer service-level config.

---

## Checklist (Required)

- [x] Builds locally with no errors (`make build`).
- [x] Linter passes (`make lint`) and tests pass (`make test`).
- [x] No secrets/keys/tokens added.
- [x] CLI behavior and flags remain backward compatible **or** breaking changes are documented here.

## Checklist (Recommended)

- [x] Docs/help/examples updated if behavior/flags changed.
- [x] Edge cases considered (empty inputs, timeouts, invalid paths).

---


**Breaking config note**: top-level `tls` was removed in favor of per-service ingress TLS blocks under `components.*.tls`.