### PR TITLE
fix(auth): align AAI URL handling across docker and k8s

### DIFF
--- a/common/auth.go
+++ b/common/auth.go
@@ -1,0 +1,12 @@
+package common
+
+import "strings"
+
+// TrimAuthURL normalizes configured AAI endpoint values to auth root URL form.
+func TrimAuthURL(endpoint string) string {
+	endpoint = strings.TrimSpace(endpoint)
+	endpoint = strings.TrimSuffix(endpoint, "/")
+	endpoint = strings.TrimSuffix(endpoint, "/oauth2/userinfo")
+
+	return endpoint
+}

--- a/common/auth_test.go
+++ b/common/auth_test.go
@@ -1,0 +1,52 @@
+package common
+
+import "testing"
+
+func TestTrimAuthURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "whitespace string",
+			input:    "   ",
+			expected: "",
+		},
+		{
+			name:     "already auth root",
+			input:    "https://auth.example.com",
+			expected: "https://auth.example.com",
+		},
+		{
+			name:     "auth root with trailing slash",
+			input:    "https://auth.example.com/",
+			expected: "https://auth.example.com",
+		},
+		{
+			name:     "userinfo endpoint",
+			input:    "https://auth.example.com/oauth2/userinfo",
+			expected: "https://auth.example.com",
+		},
+		{
+			name:     "userinfo endpoint with trailing slash",
+			input:    "https://auth.example.com/oauth2/userinfo/",
+			expected: "https://auth.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TrimAuthURL(tt.input)
+
+			if got != tt.expected {
+				t.Fatalf("TrimAuthURL() = %q, expected %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -274,8 +274,8 @@ func (e *EnvConfig) Validate() error {
 		}
 	}
 	if e.Components.Gateway.AAI.Enabled {
-		if e.Components.Gateway.AAI.ServiceEndpoint == "" {
-			return fmt.Errorf("aai service endpoint is required when aai is enabled")
+		if e.AAIAuthRootURL() == "" {
+			return fmt.Errorf("aai service endpoint is required when aai is enabled and embedded aai service is disabled")
 		}
 	}
 

--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -179,6 +179,8 @@ func (e *EnvConfig) EnsurePortsFree() error {
 		}
 	}
 
+	// TODO: add the free port check for the aai service too
+
 	return nil
 }
 

--- a/pkg/docker/config/config_validate_test.go
+++ b/pkg/docker/config/config_validate_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 const (
-	externalAAIUserinfoEndpoint = "https://auth.example.com/oauth2/userinfo"
+	externalAAIAuthRootURL      = "https://auth.example.com"
+	externalAAIUserinfoEndpoint = externalAAIAuthRootURL + "/oauth2/userinfo"
 )
 
 func TestEnvConfigValidate_RequiresCoreImages(t *testing.T) {
@@ -187,12 +188,12 @@ func TestEnvConfigValidate_AAI(t *testing.T) {
 			errContains: "aai service image is required when aai service is enabled",
 		},
 		{
-			name: "gateway aai requires service endpoint",
+			name: "gateway aai requires service endpoint when embedded aai is disabled",
 			mutate: func(cfg *config.EnvConfig) {
 				cfg.Components.Gateway.AAI.Enabled = true
 				cfg.Components.Gateway.AAI.ServiceEndpoint = ""
 			},
-			errContains: "aai service endpoint is required when aai is enabled",
+			errContains: "aai service endpoint is required when aai is enabled and embedded aai service is disabled",
 		},
 	}
 
@@ -216,8 +217,19 @@ func TestEnvConfigValidate_AAI(t *testing.T) {
 func TestEnvConfigValidate_GatewayAAIWithExternalEndpointIsValid(t *testing.T) {
 	cfg := NewTestConfig(t, "test-env").Build()
 	cfg.Components.Gateway.AAI.Enabled = true
-	cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIUserinfoEndpoint
+	cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIAuthRootURL
 	cfg.Components.AAIService.Enabled = false
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestEnvConfigValidate_GatewayAAIWithEmbeddedAAIAndEmptyEndpointIsValid(t *testing.T) {
+	cfg := NewTestConfig(t, "test-env").Build()
+	cfg.Components.Gateway.AAI.Enabled = true
+	cfg.Components.Gateway.AAI.ServiceEndpoint = ""
+	cfg.Components.AAIService.Enabled = true
 
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v, want nil", err)
@@ -241,7 +253,7 @@ func TestEnvConfigValidate_BackofficeRequiresAuth(t *testing.T) {
 func TestEnvConfigValidate_BackofficeWithoutEmbeddedAAIIsValid(t *testing.T) {
 	cfg := NewTestConfig(t, "test-env").WithBackoffice(true).Build()
 	cfg.Components.Gateway.AAI.Enabled = true
-	cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIUserinfoEndpoint
+	cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIAuthRootURL
 	cfg.Components.AAIService.Enabled = false
 
 	if err := cfg.Validate(); err != nil {
@@ -326,7 +338,7 @@ func TestEnvConfigValidate_ServiceAuthRequiresGatewayAAI(t *testing.T) {
 func TestEnvConfigValidate_ServiceAuthIsValidWithGatewayAAI(t *testing.T) {
 	cfg := NewTestConfig(t, "test-env").Build()
 	cfg.Components.Gateway.AAI.Enabled = true
-	cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIUserinfoEndpoint
+	cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIAuthRootURL
 	cfg.Components.ResourcesService.Auth.Enabled = true
 
 	if err := cfg.Validate(); err != nil {

--- a/pkg/docker/config/default.yaml
+++ b/pkg/docker/config/default.yaml
@@ -20,9 +20,10 @@ components:
       # When enabled, the gateway will call the configured userinfo endpoint to validate authenticated requests.
       # This can point to the embedded aai_service below or to an external provider.
       enabled: false
-      # Userinfo endpoint used by the gateway when AAI is enabled.
-      # Use the embedded service default below for local auth, or replace it with an external provider endpoint.
-      service_endpoint: "http://aai-service:8080/oauth2/userinfo"
+      # External URL where the AAI service is reachable (e.g. https://auth.example.com).
+      # The gateway userinfo endpoint is derived from this URL by appending /oauth2/userinfo.
+      # Leave empty to auto-generate it as <protocol>://<domain>:<aai_service.port> when embedded aai_service is enabled.
+      service_endpoint: ""
 
     # Base URL path for the API gateway. Must start with / and end with /api/v1
     base_url: "/api/v1"

--- a/pkg/docker/config/model.go
+++ b/pkg/docker/config/model.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/EPOS-ERIC/epos-opensource/common"
 )
@@ -235,9 +234,7 @@ func (e *EnvConfig) AAIAuthRootURL() string {
 		return ""
 	}
 
-	endpoint := strings.TrimSpace(e.Components.Gateway.AAI.ServiceEndpoint)
-	endpoint = strings.TrimSuffix(endpoint, "/")
-	endpoint = strings.TrimSuffix(endpoint, "/oauth2/userinfo")
+	endpoint := common.TrimAuthURL(e.Components.Gateway.AAI.ServiceEndpoint)
 
 	if endpoint != "" {
 		return endpoint

--- a/pkg/docker/config/model.go
+++ b/pkg/docker/config/model.go
@@ -1,6 +1,11 @@
 package config
 
-import "github.com/EPOS-ERIC/epos-opensource/common"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/EPOS-ERIC/epos-opensource/common"
+)
 
 // EnvConfig represents the full Docker environment configuration schema.
 type EnvConfig struct {
@@ -222,4 +227,25 @@ func (e *EnvConfig) UsingDefaultPorts() bool {
 		}
 	}
 	return true
+}
+
+// AAIAuthRootURL returns the externally reachable auth root URL used by UIs.
+func (e *EnvConfig) AAIAuthRootURL() string {
+	if !e.Components.Gateway.AAI.Enabled {
+		return ""
+	}
+
+	endpoint := strings.TrimSpace(e.Components.Gateway.AAI.ServiceEndpoint)
+	endpoint = strings.TrimSuffix(endpoint, "/")
+	endpoint = strings.TrimSuffix(endpoint, "/oauth2/userinfo")
+
+	if endpoint != "" {
+		return endpoint
+	}
+
+	if e.Components.AAIService.Enabled {
+		return fmt.Sprintf("%s://%s:%d", e.Protocol, e.Domain, e.Components.AAIService.Port)
+	}
+
+	return ""
 }

--- a/pkg/docker/config/model.go
+++ b/pkg/docker/config/model.go
@@ -246,3 +246,22 @@ func (e *EnvConfig) AAIAuthRootURL() string {
 
 	return ""
 }
+
+// AAIServiceEndpoint returns gateway-reachable AAI service endpoint.
+func (e *EnvConfig) AAIServiceEndpoint() string {
+	if !e.Components.Gateway.AAI.Enabled {
+		return ""
+	}
+
+	endpoint := common.TrimAuthURL(e.Components.Gateway.AAI.ServiceEndpoint)
+
+	if endpoint != "" {
+		return endpoint
+	}
+
+	if e.Components.AAIService.Enabled {
+		return "http://aai-service:8080"
+	}
+
+	return ""
+}

--- a/pkg/docker/config/render_test.go
+++ b/pkg/docker/config/render_test.go
@@ -101,7 +101,7 @@ func TestDockerEnvConfig_Render(t *testing.T) {
 			wantContains: map[string][]string{
 				".env": {
 					"IS_AAI_ENABLED=true",
-					"AAI_SERVICE_ENDPOINT=http://localhost:35000/oauth2/userinfo",
+					"AAI_SERVICE_ENDPOINT=http://aai-service:8080/oauth2/userinfo",
 					"AUTH_ROOT_URL=http://localhost:35000",
 					"ADMIN_NAME=EPOS",
 					"ADMIN_SURNAME=User",

--- a/pkg/docker/config/render_test.go
+++ b/pkg/docker/config/render_test.go
@@ -101,7 +101,8 @@ func TestDockerEnvConfig_Render(t *testing.T) {
 			wantContains: map[string][]string{
 				".env": {
 					"IS_AAI_ENABLED=true",
-					"AAI_SERVICE_ENDPOINT=http://aai-service:8080/oauth2/userinfo",
+					"AAI_SERVICE_ENDPOINT=http://localhost:35000/oauth2/userinfo",
+					"AUTH_ROOT_URL=http://localhost:35000",
 					"ADMIN_NAME=EPOS",
 					"ADMIN_SURNAME=User",
 					"ADMIN_EMAIL=epos@epos.eu",
@@ -112,11 +113,11 @@ func TestDockerEnvConfig_Render(t *testing.T) {
 			},
 		},
 		{
-			name: "embedded aai disabled excludes service specific env vars and compose service",
+			name: "embedded aai disabled supports external auth root url",
 			config: func() *config.EnvConfig {
 				cfg := NewTestConfig(t, "test-external-aai").Build()
 				cfg.Components.Gateway.AAI.Enabled = true
-				cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIUserinfoEndpoint
+				cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIAuthRootURL
 				return cfg
 			}(),
 			wantErr: false,
@@ -124,6 +125,7 @@ func TestDockerEnvConfig_Render(t *testing.T) {
 				".env": {
 					"IS_AAI_ENABLED=true",
 					"AAI_SERVICE_ENDPOINT=" + externalAAIUserinfoEndpoint,
+					"AUTH_ROOT_URL=" + externalAAIAuthRootURL,
 				},
 			},
 			notContains: map[string][]string{
@@ -187,4 +189,19 @@ func TestDockerEnvConfig_Render_EmailSenderAuth(t *testing.T) {
 
 	got := MustRender(t, cfg)
 	ContentContains(t, got[".env"], ".env", []string{"LOAD_EMAIL_SENDER_API=true:true"})
+}
+
+func TestDockerEnvConfig_Render_AAIEndpointNormalization(t *testing.T) {
+	cfg := NewTestConfig(t, "test-aai-normalize").Build()
+	cfg.Components.Gateway.AAI.Enabled = true
+	cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIUserinfoEndpoint
+
+	got := MustRender(t, cfg)
+	ContentContains(t, got[".env"], ".env", []string{
+		"AAI_SERVICE_ENDPOINT=" + externalAAIUserinfoEndpoint,
+		"AUTH_ROOT_URL=" + externalAAIAuthRootURL,
+	})
+	ContentExcludes(t, got[".env"], ".env", []string{
+		"AAI_SERVICE_ENDPOINT=" + externalAAIUserinfoEndpoint + "/oauth2/userinfo",
+	})
 }

--- a/pkg/docker/config/templates/.env.tmpl
+++ b/pkg/docker/config/templates/.env.tmpl
@@ -62,9 +62,10 @@ LOAD_EMAIL_SENDER_API={{.Components.EmailSenderService.Auth.Enabled}}:{{.Compone
 LOAD_SHARING_API={{.Components.SharingService.Auth.Enabled}}:{{.Components.SharingService.Auth.OnlyAdmin}}
 {{- end}}
 
-# if setting this to true make sure to also set the AAI_SERVICE_ENDPOINT variable to a compatible provider
 IS_AAI_ENABLED={{.Components.Gateway.AAI.Enabled}}
-AAI_SERVICE_ENDPOINT={{.Components.Gateway.AAI.ServiceEndpoint}}
+{{- if and .Components.Gateway.AAI.Enabled .AAIAuthRootURL}}
+AAI_SERVICE_ENDPOINT={{.AAIAuthRootURL}}/oauth2/userinfo
+{{- end}}
 
 {{- if .Components.AAIService.Enabled}}
 ADMIN_NAME={{.Components.AAIService.Name}}
@@ -97,9 +98,13 @@ GATEWAY_PORT={{.Components.Gateway.Port}}
 {{- if .Components.Backoffice.Enabled}}
 BACKOFFICE_PORT={{.Components.Backoffice.GUI.Port}}
 {{- end}}
-{{- if .Components.AAIService.Enabled}}
+{{- if .Components.Gateway.AAI.Enabled }}
+	{{- if .Components.AAIService.Enabled }}
 AAI_SERVICE_PORT={{.Components.AAIService.Port}}
-AUTH_ROOT_URL={{.Protocol}}://{{.Domain}}:{{.Components.AAIService.Port}}
+	{{- end}}
+	{{- if .AAIAuthRootURL}}
+AUTH_ROOT_URL={{.AAIAuthRootURL}}
+	{{- end}}
 {{- end}}
 
 # Docker Images and Tags

--- a/pkg/docker/config/templates/.env.tmpl
+++ b/pkg/docker/config/templates/.env.tmpl
@@ -63,8 +63,8 @@ LOAD_SHARING_API={{.Components.SharingService.Auth.Enabled}}:{{.Components.Shari
 {{- end}}
 
 IS_AAI_ENABLED={{.Components.Gateway.AAI.Enabled}}
-{{- if and .Components.Gateway.AAI.Enabled .AAIAuthRootURL}}
-AAI_SERVICE_ENDPOINT={{.AAIAuthRootURL}}/oauth2/userinfo
+{{- if and .Components.Gateway.AAI.Enabled .AAIServiceEndpoint}}
+AAI_SERVICE_ENDPOINT={{.AAIServiceEndpoint}}/oauth2/userinfo
 {{- end}}
 
 {{- if .Components.AAIService.Enabled}}

--- a/pkg/docker/config/templates/docker-compose.yaml.tmpl
+++ b/pkg/docker/config/templates/docker-compose.yaml.tmpl
@@ -413,9 +413,13 @@ services:
 {{- end}}
 
 volumes:
-  converter:
   psqldata:
+{{- if .Components.Converter.Enabled}}
+  converter:
+{{- end}}
+{{- if .Components.AAIService.Enabled}}
   aai:
+{{- end}}
 
 networks:
   epos_network:

--- a/pkg/docker/config/testing_test.go
+++ b/pkg/docker/config/testing_test.go
@@ -77,7 +77,7 @@ func (b *TestConfigBuilder) Build() *config.EnvConfig {
 				Port:    b.gatewayPort,
 				AAI: config.AAI{
 					Enabled:         false,
-					ServiceEndpoint: "http://aai-service:8080/oauth2/userinfo",
+					ServiceEndpoint: "",
 				},
 			},
 			Backoffice: config.Backoffice{

--- a/pkg/k8s/config/config.go
+++ b/pkg/k8s/config/config.go
@@ -227,8 +227,10 @@ func (c *Config) Validate() error {
 		}
 	}
 	if c.Components.Gateway.AAI.Enabled {
-		if c.Components.Gateway.AAI.ServiceEndpoint == "" {
-			return fmt.Errorf("aai service endpoint is required when aai is enabled")
+		aaiServiceEndpoint := common.TrimAuthURL(c.Components.Gateway.AAI.ServiceEndpoint)
+
+		if aaiServiceEndpoint == "" && !c.Components.AAIService.Enabled {
+			return fmt.Errorf("aai service endpoint is required when aai is enabled and embedded aai service is disabled")
 		}
 	}
 

--- a/pkg/k8s/config/config_validate_test.go
+++ b/pkg/k8s/config/config_validate_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 )
 
-const externalAAIUserinfoEndpoint = "https://auth.example.com/oauth2/userinfo"
+const (
+	externalAAIAuthRootURL      = "https://auth.example.com"
+	externalAAIUserinfoEndpoint = externalAAIAuthRootURL + "/oauth2/userinfo"
+)
 
 func TestConfigValidate_Requirements(t *testing.T) {
 	tests := []struct {
@@ -133,13 +136,13 @@ func TestConfigValidate_Requirements(t *testing.T) {
 			errContains: "aai service tls secret_name is required when tls is enabled",
 		},
 		{
-			name: "aai service endpoint is required when aai is enabled",
+			name: "aai service endpoint is required when aai is enabled and embedded aai is disabled",
 			mutate: func(cfg *Config) {
 				enableAAI(cfg)
 				cfg.Components.Gateway.AAI.ServiceEndpoint = ""
 			},
 			wantErr:     true,
-			errContains: "aai service endpoint is required when aai is enabled",
+			errContains: "aai service endpoint is required when aai is enabled and embedded aai service is disabled",
 		},
 		{
 			name: "monitoring url is required when monitoring is enabled",
@@ -308,8 +311,30 @@ func TestConfigValidate_AAI(t *testing.T) {
 func TestConfigValidate_GatewayAAIWithExternalEndpointIsValid(t *testing.T) {
 	cfg := GetDefaultConfig()
 	cfg.Components.Gateway.AAI.Enabled = true
+	cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIAuthRootURL
+	cfg.Components.AAIService.Enabled = false
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestConfigValidate_GatewayAAIWithExternalUserinfoEndpointIsValid(t *testing.T) {
+	cfg := GetDefaultConfig()
+	cfg.Components.Gateway.AAI.Enabled = true
 	cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIUserinfoEndpoint
 	cfg.Components.AAIService.Enabled = false
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestConfigValidate_GatewayAAIWithEmbeddedAAIAndEmptyEndpointIsValid(t *testing.T) {
+	cfg := GetDefaultConfig()
+	cfg.Components.Gateway.AAI.Enabled = true
+	cfg.Components.Gateway.AAI.ServiceEndpoint = ""
+	cfg.Components.AAIService.Enabled = true
 
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("Validate() error = %v, want nil", err)
@@ -408,7 +433,7 @@ func TestConfigValidate_ServiceAuthRequiresGatewayAAI(t *testing.T) {
 func TestConfigValidate_ServiceAuthIsValidWithGatewayAAI(t *testing.T) {
 	cfg := GetDefaultConfig()
 	cfg.Components.Gateway.AAI.Enabled = true
-	cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIUserinfoEndpoint
+	cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIAuthRootURL
 	cfg.Components.ResourcesService.Auth.Enabled = true
 
 	if err := cfg.Validate(); err != nil {

--- a/pkg/k8s/config/helm/templates/_helpers.tpl
+++ b/pkg/k8s/config/helm/templates/_helpers.tpl
@@ -100,11 +100,22 @@ jdbc:postgresql://{{ default .Values.components.metadata_database.host }}:{{ .Va
 {{- end -}}
 {{- end -}}
 
+{{- define "epos.gatewayAAIServiceEndpoint" -}}
+{{- if .Values.components.gateway.aai.enabled -}}
+{{- $endpoint := .Values.components.gateway.aai.service_endpoint | default "" | trim | trimSuffix "/" | trimSuffix "/oauth2/userinfo" -}}
+{{- if $endpoint -}}
+{{- $endpoint -}}
+{{- else if .Values.components.aai_service.enabled -}}
+http://aai-service:8080
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "epos.gatewayAAIUserinfoEndpoint" -}}
 {{- if .Values.components.gateway.aai.enabled -}}
-{{- $authRootURL := include "epos.aaiAuthRootURL" . | trim | trimSuffix "/" -}}
-{{- if $authRootURL -}}
-{{- printf "%s/oauth2/userinfo" $authRootURL -}}
+{{- $serviceEndpoint := include "epos.gatewayAAIServiceEndpoint" . | trim | trimSuffix "/" -}}
+{{- if $serviceEndpoint -}}
+{{- printf "%s/oauth2/userinfo" $serviceEndpoint -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/k8s/config/helm/templates/_helpers.tpl
+++ b/pkg/k8s/config/helm/templates/_helpers.tpl
@@ -82,3 +82,29 @@ jdbc:postgresql://{{ default .Values.components.metadata_database.host }}:{{ .Va
       sleep 1;
     done
 {{- end -}}
+
+{{- define "epos.defaultAAIAuthRootURL" -}}
+{{- if .Values.url_prefix_namespace -}}
+{{- printf "%s://%s/%s/aai" .Values.protocol .Values.domain .Release.Namespace -}}
+{{- else -}}
+{{- printf "%s://%s/aai" .Values.protocol .Values.domain -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "epos.aaiAuthRootURL" -}}
+{{- $endpoint := .Values.components.gateway.aai.service_endpoint | default "" | trim | trimSuffix "/" | trimSuffix "/oauth2/userinfo" -}}
+{{- if $endpoint -}}
+{{- $endpoint -}}
+{{- else -}}
+{{- include "epos.defaultAAIAuthRootURL" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "epos.gatewayAAIUserinfoEndpoint" -}}
+{{- if .Values.components.gateway.aai.enabled -}}
+{{- $authRootURL := include "epos.aaiAuthRootURL" . | trim | trimSuffix "/" -}}
+{{- if $authRootURL -}}
+{{- printf "%s/oauth2/userinfo" $authRootURL -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/pkg/k8s/config/helm/templates/backoffice-ui.yaml
+++ b/pkg/k8s/config/helm/templates/backoffice-ui.yaml
@@ -5,11 +5,7 @@ BASE_URL: /{{ .Release.Namespace }}{{ .Values.components.backoffice.gui.base_url
 BASE_URL: {{ .Values.components.backoffice.gui.base_url }}
 {{- end }}
 API_HOST: http://gateway:5000/api
-{{- if .Values.url_prefix_namespace }}
-AUTH_ROOT_URL: {{ printf "%s://%s/%s/aai" .Values.protocol .Values.domain .Release.Namespace | quote }}
-{{- else }}
-AUTH_ROOT_URL: {{ printf "%s://%s/aai" .Values.protocol .Values.domain | quote }}
-{{- end }}
+AUTH_ROOT_URL: {{ include "epos.aaiAuthRootURL" . | quote }}
 {{- end -}}
 
 {{- if .Values.components.backoffice.enabled }}

--- a/pkg/k8s/config/helm/templates/dataportal.yaml
+++ b/pkg/k8s/config/helm/templates/dataportal.yaml
@@ -5,11 +5,7 @@ BASE_URL: /{{ .Release.Namespace }}{{ .Values.components.platform_gui.base_url }
 BASE_URL: {{ .Values.components.platform_gui.base_url }}
 {{- end }}
 API_HOST: http://gateway:5000/api
-{{- if .Values.url_prefix_namespace }}
-AUTH_ROOT_URL: {{ printf "%s://%s/%s/aai" .Values.protocol .Values.domain .Release.Namespace | quote }}
-{{- else }}
-AUTH_ROOT_URL: {{ printf "%s://%s/aai" .Values.protocol .Values.domain | quote }}
-{{- end }}
+AUTH_ROOT_URL: {{ include "epos.aaiAuthRootURL" . | quote }}
 {{- end -}}
 
 ---

--- a/pkg/k8s/config/helm/templates/gateway.yaml
+++ b/pkg/k8s/config/helm/templates/gateway.yaml
@@ -16,7 +16,7 @@ LOAD_EMAIL_SENDER_API: "{{ .Values.components.email_sender_service.auth.enabled 
 {{- end}}
 
 IS_AAI_ENABLED: "{{ .Values.components.gateway.aai.enabled }}"
-AAI_SERVICE_ENDPOINT: "{{ .Values.components.gateway.aai.service_endpoint }}"
+AAI_SERVICE_ENDPOINT: "{{ include "epos.gatewayAAIUserinfoEndpoint" . }}"
 
 {{- if .Values.url_prefix_namespace }}
 BASECONTEXT: "/{{ .Release.Namespace }}"

--- a/pkg/k8s/config/helm/values.yaml
+++ b/pkg/k8s/config/helm/values.yaml
@@ -27,9 +27,10 @@ components:
       # When enabled, the gateway will call the configured userinfo endpoint to validate authenticated requests.
       # This can point to the embedded aai_service below or to an external provider.
       enabled: false
-      # Userinfo endpoint used by the gateway when AAI is enabled.
-      # Use the embedded service default below for local auth, or replace it with an external provider endpoint.
-      service_endpoint: "http://aai-service:8080/oauth2/userinfo"
+      # External URL where the AAI service is reachable (e.g. https://auth.example.com).
+      # The gateway userinfo endpoint is derived from this URL by appending /oauth2/userinfo.
+      # Leave empty to auto-generate it as <protocol>://<domain>[/<namespace>]/aai.
+      service_endpoint: ""
 
     # Base URL path for the API gateway. Must start with / and end with /api/v1
     base_url: "/api/v1/" # it needs to end with /api/v1

--- a/pkg/k8s/config/helm/values.yaml
+++ b/pkg/k8s/config/helm/values.yaml
@@ -29,7 +29,8 @@ components:
       enabled: false
       # External URL where the AAI service is reachable (e.g. https://auth.example.com).
       # The gateway userinfo endpoint is derived from this URL by appending /oauth2/userinfo.
-      # Leave empty to auto-generate it as <protocol>://<domain>[/<namespace>]/aai.
+      # Leave empty to use the embedded aai_service endpoint when enabled.
+      # UI auth root URL still defaults to <protocol>://<domain>[/<namespace>]/aai.
       service_endpoint: ""
 
     # Base URL path for the API gateway. Must start with / and end with /api/v1

--- a/pkg/k8s/config/render_test.go
+++ b/pkg/k8s/config/render_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 const (
-	externalAAIUserinfoEndpoint = "https://auth.example.com/oauth2/userinfo"
+	externalAAIAuthRootURL      = "https://auth.example.com"
+	externalAAIUserinfoEndpoint = externalAAIAuthRootURL + "/oauth2/userinfo"
 	dataportalTLSSecret         = "dataportal-tls"
 	gatewayTLSSecret            = "gateway-tls"
 	certManagerIssuerAnnotation = "cert-manager.io/cluster-issuer: letsencrypt"
@@ -124,7 +125,7 @@ func TestConfigRender(t *testing.T) {
 			wantContains: map[string][]string{
 				"templates/gateway.yaml": {
 					`IS_AAI_ENABLED: "true"`,
-					`AAI_SERVICE_ENDPOINT: "http://aai-service:8080/oauth2/userinfo"`,
+					`AAI_SERVICE_ENDPOINT: "http://localhost/test-aai/aai/oauth2/userinfo"`,
 					"wait-for-aai-service",
 				},
 				"templates/aai-service.yaml": {
@@ -141,7 +142,7 @@ func TestConfigRender(t *testing.T) {
 			},
 		},
 		{
-			name: "embedded aai disabled supports external endpoint without manifest",
+			name: "embedded aai disabled supports external endpoint and auth root without manifest",
 			mutate: func(cfg *config.Config) {
 				cfg.Name = "test-external-aai"
 				cfg.Components.Gateway.AAI.Enabled = true
@@ -151,6 +152,9 @@ func TestConfigRender(t *testing.T) {
 				"templates/gateway.yaml": {
 					`IS_AAI_ENABLED: "true"`,
 					`AAI_SERVICE_ENDPOINT: "` + externalAAIUserinfoEndpoint + `"`,
+				},
+				"templates/dataportal.yaml": {
+					`AUTH_ROOT_URL: "` + externalAAIAuthRootURL + `"`,
 				},
 			},
 			notContains: map[string][]string{

--- a/pkg/k8s/config/render_test.go
+++ b/pkg/k8s/config/render_test.go
@@ -125,8 +125,11 @@ func TestConfigRender(t *testing.T) {
 			wantContains: map[string][]string{
 				"templates/gateway.yaml": {
 					`IS_AAI_ENABLED: "true"`,
-					`AAI_SERVICE_ENDPOINT: "http://localhost/test-aai/aai/oauth2/userinfo"`,
+					`AAI_SERVICE_ENDPOINT: "http://aai-service:8080/oauth2/userinfo"`,
 					"wait-for-aai-service",
+				},
+				"templates/dataportal.yaml": {
+					`AUTH_ROOT_URL: "http://localhost/test-aai/aai"`,
 				},
 				"templates/aai-service.yaml": {
 					"name: aai-service",


### PR DESCRIPTION
## Summary

Align AAI URL behavior between Docker and Helm so gateway and UIs use the same external auth root. Treat `service_endpoint` as auth root URL, derive the gateway userinfo endpoint from it, and keep embedded AAI fallback when the endpoint is empty. Add a shared URL trim helper to avoid drift between docker and k8s validation logic.

---

## Checklist (Required)
- [x] Builds locally with no errors (`make build`).
- [x] Linter passes (`make lint`) and tests pass (`make test`).
- [x] No secrets/keys/tokens added.
- [x] CLI behavior and flags remain backward compatible **or** breaking changes are documented here.

## Checklist (Recommended)
- [x] Docs/help/examples updated if behavior/flags changed.
- [x] Edge cases considered (empty inputs, timeouts, invalid paths).