### PR TITLE
feat(auth): add AAI gateway_endpoint override

### DIFF
--- a/pkg/docker/config/config_validate_test.go
+++ b/pkg/docker/config/config_validate_test.go
@@ -195,6 +195,16 @@ func TestEnvConfigValidate_AAI(t *testing.T) {
 			},
 			errContains: "aai service endpoint is required when aai is enabled and embedded aai service is disabled",
 		},
+		{
+			name: "gateway endpoint does not replace service endpoint validation",
+			mutate: func(cfg *config.EnvConfig) {
+				cfg.Components.Gateway.AAI.Enabled = true
+				cfg.Components.Gateway.AAI.ServiceEndpoint = ""
+				cfg.Components.Gateway.AAI.GatewayEndpoint = externalAAIAuthRootURL
+				cfg.Components.AAIService.Enabled = false
+			},
+			errContains: "aai service endpoint is required when aai is enabled and embedded aai service is disabled",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/docker/config/default.yaml
+++ b/pkg/docker/config/default.yaml
@@ -24,6 +24,9 @@ components:
       # The gateway userinfo endpoint is derived from this URL by appending /oauth2/userinfo.
       # Leave empty to auto-generate it as <protocol>://<domain>:<aai_service.port> when embedded aai_service is enabled.
       service_endpoint: ""
+      # Optional endpoint override used only by the gateway for AAI_SERVICE_ENDPOINT.
+      # Leave empty to keep existing behavior and use service_endpoint (or embedded aai_service).
+      gateway_endpoint: ""
 
     # Base URL path for the API gateway. Must start with / and end with /api/v1
     base_url: "/api/v1"

--- a/pkg/docker/config/model.go
+++ b/pkg/docker/config/model.go
@@ -26,6 +26,7 @@ type PlatformGUI struct {
 type AAI struct {
 	Enabled         bool   `yaml:"enabled"`
 	ServiceEndpoint string `yaml:"service_endpoint"`
+	GatewayEndpoint string `yaml:"gateway_endpoint"`
 }
 
 // SwaggerPage configures API documentation metadata.
@@ -251,6 +252,12 @@ func (e *EnvConfig) AAIAuthRootURL() string {
 func (e *EnvConfig) AAIServiceEndpoint() string {
 	if !e.Components.Gateway.AAI.Enabled {
 		return ""
+	}
+
+	gatewayEndpoint := common.TrimAuthURL(e.Components.Gateway.AAI.GatewayEndpoint)
+
+	if gatewayEndpoint != "" {
+		return gatewayEndpoint
 	}
 
 	endpoint := common.TrimAuthURL(e.Components.Gateway.AAI.ServiceEndpoint)

--- a/pkg/docker/config/render_test.go
+++ b/pkg/docker/config/render_test.go
@@ -205,3 +205,22 @@ func TestDockerEnvConfig_Render_AAIEndpointNormalization(t *testing.T) {
 		"AAI_SERVICE_ENDPOINT=" + externalAAIUserinfoEndpoint + "/oauth2/userinfo",
 	})
 }
+
+func TestDockerEnvConfig_Render_GatewayAAIEndpointOverride(t *testing.T) {
+	const gatewayAAIUserinfoEndpoint = "https://gateway-auth.example.com/oauth2/userinfo"
+
+	cfg := NewTestConfig(t, "test-aai-gateway-override").Build()
+	cfg.Components.Gateway.AAI.Enabled = true
+	cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIAuthRootURL
+	cfg.Components.Gateway.AAI.GatewayEndpoint = gatewayAAIUserinfoEndpoint
+
+	got := MustRender(t, cfg)
+	ContentContains(t, got[".env"], ".env", []string{
+		"AAI_SERVICE_ENDPOINT=" + gatewayAAIUserinfoEndpoint,
+		"AUTH_ROOT_URL=" + externalAAIAuthRootURL,
+	})
+	ContentExcludes(t, got[".env"], ".env", []string{
+		"AAI_SERVICE_ENDPOINT=" + externalAAIUserinfoEndpoint,
+		"AAI_SERVICE_ENDPOINT=" + gatewayAAIUserinfoEndpoint + "/oauth2/userinfo",
+	})
+}

--- a/pkg/k8s/config/config_validate_test.go
+++ b/pkg/k8s/config/config_validate_test.go
@@ -145,6 +145,16 @@ func TestConfigValidate_Requirements(t *testing.T) {
 			errContains: "aai service endpoint is required when aai is enabled and embedded aai service is disabled",
 		},
 		{
+			name: "gateway endpoint does not replace service endpoint validation",
+			mutate: func(cfg *Config) {
+				enableAAI(cfg)
+				cfg.Components.Gateway.AAI.ServiceEndpoint = ""
+				cfg.Components.Gateway.AAI.GatewayEndpoint = externalAAIAuthRootURL
+			},
+			wantErr:     true,
+			errContains: "aai service endpoint is required when aai is enabled and embedded aai service is disabled",
+		},
+		{
 			name: "monitoring url is required when monitoring is enabled",
 			mutate: func(cfg *Config) {
 				enableMonitoring(cfg)

--- a/pkg/k8s/config/helm/templates/_helpers.tpl
+++ b/pkg/k8s/config/helm/templates/_helpers.tpl
@@ -102,11 +102,16 @@ jdbc:postgresql://{{ default .Values.components.metadata_database.host }}:{{ .Va
 
 {{- define "epos.gatewayAAIServiceEndpoint" -}}
 {{- if .Values.components.gateway.aai.enabled -}}
-{{- $endpoint := .Values.components.gateway.aai.service_endpoint | default "" | trim | trimSuffix "/" | trimSuffix "/oauth2/userinfo" -}}
-{{- if $endpoint -}}
-{{- $endpoint -}}
+{{- $gatewayEndpoint := .Values.components.gateway.aai.gateway_endpoint | default "" | trim | trimSuffix "/" | trimSuffix "/oauth2/userinfo" -}}
+{{- if $gatewayEndpoint -}}
+{{- $gatewayEndpoint -}}
+{{- else -}}
+{{- $serviceEndpoint := .Values.components.gateway.aai.service_endpoint | default "" | trim | trimSuffix "/" | trimSuffix "/oauth2/userinfo" -}}
+{{- if $serviceEndpoint -}}
+{{- $serviceEndpoint -}}
 {{- else if .Values.components.aai_service.enabled -}}
 http://aai-service:8080
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/k8s/config/helm/values.yaml
+++ b/pkg/k8s/config/helm/values.yaml
@@ -32,6 +32,9 @@ components:
       # Leave empty to use the embedded aai_service endpoint when enabled.
       # UI auth root URL still defaults to <protocol>://<domain>[/<namespace>]/aai.
       service_endpoint: ""
+      # Optional endpoint override used only by the gateway for AAI_SERVICE_ENDPOINT.
+      # Leave empty to keep existing behavior and use service_endpoint (or embedded aai_service).
+      gateway_endpoint: ""
 
     # Base URL path for the API gateway. Must start with / and end with /api/v1
     base_url: "/api/v1/" # it needs to end with /api/v1

--- a/pkg/k8s/config/model.go
+++ b/pkg/k8s/config/model.go
@@ -33,6 +33,7 @@ type PlatformGUI struct {
 type AAI struct {
 	Enabled         bool   `yaml:"enabled"`
 	ServiceEndpoint string `yaml:"service_endpoint"`
+	GatewayEndpoint string `yaml:"gateway_endpoint"`
 }
 
 // SwaggerPage configures API documentation metadata.

--- a/pkg/k8s/config/render_test.go
+++ b/pkg/k8s/config/render_test.go
@@ -11,6 +11,7 @@ import (
 const (
 	externalAAIAuthRootURL      = "https://auth.example.com"
 	externalAAIUserinfoEndpoint = externalAAIAuthRootURL + "/oauth2/userinfo"
+	gatewayAAIUserinfoEndpoint  = "https://gateway-auth.example.com/oauth2/userinfo"
 	dataportalTLSSecret         = "dataportal-tls"
 	gatewayTLSSecret            = "gateway-tls"
 	certManagerIssuerAnnotation = "cert-manager.io/cluster-issuer: letsencrypt"
@@ -164,6 +165,30 @@ func TestConfigRender(t *testing.T) {
 				"templates/gateway.yaml":     {"wait-for-aai-service"},
 				"templates/aai-service.yaml": {"name: aai-service"},
 				"templates/pvc.yaml":         {"name: aai"},
+			},
+		},
+		{
+			name: "gateway endpoint overrides gateway aai endpoint only",
+			mutate: func(cfg *config.Config) {
+				cfg.Name = "test-gateway-aai-endpoint"
+				cfg.Components.Gateway.AAI.Enabled = true
+				cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIAuthRootURL
+				cfg.Components.Gateway.AAI.GatewayEndpoint = gatewayAAIUserinfoEndpoint + "/"
+			},
+			wantContains: map[string][]string{
+				"templates/gateway.yaml": {
+					`IS_AAI_ENABLED: "true"`,
+					`AAI_SERVICE_ENDPOINT: "` + gatewayAAIUserinfoEndpoint + `"`,
+				},
+				"templates/dataportal.yaml": {
+					`AUTH_ROOT_URL: "` + externalAAIAuthRootURL + `"`,
+				},
+			},
+			notContains: map[string][]string{
+				"templates/gateway.yaml": {
+					`AAI_SERVICE_ENDPOINT: "` + externalAAIUserinfoEndpoint + `"`,
+					`AAI_SERVICE_ENDPOINT: "` + gatewayAAIUserinfoEndpoint + `/oauth2/userinfo"`,
+				},
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Add `components.gateway.aai.gateway_endpoint` to Docker and K8s configs so gateway can use a dedicated AAI userinfo endpoint. Gateway endpoint resolution now prefers `gateway_endpoint` over `service_endpoint` for `AAI_SERVICE_ENDPOINT`, while UI `AUTH_ROOT_URL` still uses `service_endpoint`. Validation remains unchanged: `service_endpoint` is still required when gateway AAI is enabled and embedded AAI is disabled.

---

## Checklist (Required)

- [x] Builds locally with no errors (`make build`).
- [x] Linter passes (`make lint`) and tests pass (`make test`).
- [x] No secrets/keys/tokens added.
- [x] CLI behavior and flags remain backward compatible **or** breaking changes are documented here.

## Checklist (Recommended)

- [x] Docs/help/examples updated if behavior/flags changed.
- [x] Edge cases considered (empty inputs, timeouts, invalid paths).

