### PR TITLE
fix(auth): support custom userinfo endpoints

### DIFF
--- a/pkg/docker/config/default.yaml
+++ b/pkg/docker/config/default.yaml
@@ -20,12 +20,18 @@ components:
       # When enabled, the gateway will call the configured userinfo endpoint to validate authenticated requests.
       # This can point to the embedded aai_service below or to an external provider.
       enabled: false
-      # External URL where the AAI service is reachable (e.g. https://auth.example.com).
-      # The gateway userinfo endpoint is derived from this URL by appending /oauth2/userinfo.
-      # Leave empty to auto-generate it as <protocol>://<domain>:<aai_service.port> when embedded aai_service is enabled.
+      # Base URL of your AAI/identity provider (for example https://auth.example.com).
+      # This is the main auth URL used by the platform login pages. For API auth checks:
+      # - if it already ends with /userinfo, it is used as written
+      # - otherwise /oauth2/userinfo is added automatically
+      # Required when aai.enabled is true and built-in aai_service is disabled.
+      # Leave empty only when you want to use the built-in aai_service.
       service_endpoint: ""
-      # Optional endpoint override used only by the gateway for AAI_SERVICE_ENDPOINT.
-      # Leave empty to keep existing behavior and use service_endpoint (or embedded aai_service).
+      # Optional override for API auth checks.
+      # Use this when API auth should call a different endpoint than service_endpoint. Leave empty to use service_endpoint.
+      # (for example .../protocol/openid-connect/userinfo).
+      # - if it already ends with /userinfo, it is used as written
+      # - otherwise /oauth2/userinfo is added automatically
       gateway_endpoint: ""
 
     # Base URL path for the API gateway. Must start with / and end with /api/v1

--- a/pkg/docker/config/model.go
+++ b/pkg/docker/config/model.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/EPOS-ERIC/epos-opensource/common"
 )
@@ -271,4 +272,20 @@ func (e *EnvConfig) AAIServiceEndpoint() string {
 	}
 
 	return ""
+}
+
+// AAIUserinfoEndpoint returns gateway-reachable AAI userinfo endpoint.
+func (e *EnvConfig) AAIUserinfoEndpoint() string {
+	endpoint := strings.TrimSpace(e.AAIServiceEndpoint())
+	endpoint = strings.TrimSuffix(endpoint, "/")
+
+	if endpoint == "" {
+		return ""
+	}
+
+	if strings.HasSuffix(endpoint, "/userinfo") {
+		return endpoint
+	}
+
+	return endpoint + "/oauth2/userinfo"
 }

--- a/pkg/docker/config/render_test.go
+++ b/pkg/docker/config/render_test.go
@@ -224,3 +224,22 @@ func TestDockerEnvConfig_Render_GatewayAAIEndpointOverride(t *testing.T) {
 		"AAI_SERVICE_ENDPOINT=" + gatewayAAIUserinfoEndpoint + "/oauth2/userinfo",
 	})
 }
+
+func TestDockerEnvConfig_Render_GatewayAAIEndpointOverridePreservesUserinfoEndpoint(t *testing.T) {
+	const gatewayAAIKeycloakUserinfoEndpoint = "https://login.envri.eu/auth/realms/envri/protocol/openid-connect/userinfo"
+
+	cfg := NewTestConfig(t, "test-aai-gateway-keycloak-override").Build()
+	cfg.Components.Gateway.AAI.Enabled = true
+	cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIAuthRootURL
+	cfg.Components.Gateway.AAI.GatewayEndpoint = gatewayAAIKeycloakUserinfoEndpoint
+
+	got := MustRender(t, cfg)
+	ContentContains(t, got[".env"], ".env", []string{
+		"AAI_SERVICE_ENDPOINT=" + gatewayAAIKeycloakUserinfoEndpoint,
+		"AUTH_ROOT_URL=" + externalAAIAuthRootURL,
+	})
+	ContentExcludes(t, got[".env"], ".env", []string{
+		"AAI_SERVICE_ENDPOINT=" + externalAAIUserinfoEndpoint,
+		"AAI_SERVICE_ENDPOINT=" + gatewayAAIKeycloakUserinfoEndpoint + "/oauth2/userinfo",
+	})
+}

--- a/pkg/docker/config/templates/.env.tmpl
+++ b/pkg/docker/config/templates/.env.tmpl
@@ -63,8 +63,8 @@ LOAD_SHARING_API={{.Components.SharingService.Auth.Enabled}}:{{.Components.Shari
 {{- end}}
 
 IS_AAI_ENABLED={{.Components.Gateway.AAI.Enabled}}
-{{- if and .Components.Gateway.AAI.Enabled .AAIServiceEndpoint}}
-AAI_SERVICE_ENDPOINT={{.AAIServiceEndpoint}}/oauth2/userinfo
+{{- if and .Components.Gateway.AAI.Enabled .AAIUserinfoEndpoint}}
+AAI_SERVICE_ENDPOINT={{.AAIUserinfoEndpoint}}
 {{- end}}
 
 {{- if .Components.AAIService.Enabled}}

--- a/pkg/k8s/config/helm/templates/_helpers.tpl
+++ b/pkg/k8s/config/helm/templates/_helpers.tpl
@@ -120,7 +120,11 @@ http://aai-service:8080
 {{- if .Values.components.gateway.aai.enabled -}}
 {{- $serviceEndpoint := include "epos.gatewayAAIServiceEndpoint" . | trim | trimSuffix "/" -}}
 {{- if $serviceEndpoint -}}
+{{- if regexMatch "/userinfo$" $serviceEndpoint -}}
+{{- $serviceEndpoint -}}
+{{- else -}}
 {{- printf "%s/oauth2/userinfo" $serviceEndpoint -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/k8s/config/helm/values.yaml
+++ b/pkg/k8s/config/helm/values.yaml
@@ -27,13 +27,18 @@ components:
       # When enabled, the gateway will call the configured userinfo endpoint to validate authenticated requests.
       # This can point to the embedded aai_service below or to an external provider.
       enabled: false
-      # External URL where the AAI service is reachable (e.g. https://auth.example.com).
-      # The gateway userinfo endpoint is derived from this URL by appending /oauth2/userinfo.
-      # Leave empty to use the embedded aai_service endpoint when enabled.
-      # UI auth root URL still defaults to <protocol>://<domain>[/<namespace>]/aai.
+      # Base URL of your AAI/identity provider (for example https://auth.example.com).
+      # This is the main auth URL used by the platform login pages. For API auth checks:
+      # - if it already ends with /userinfo, it is used as written
+      # - otherwise /oauth2/userinfo is added automatically
+      # Required when aai.enabled is true and built-in aai_service is disabled.
+      # Leave empty only when you want to use the built-in aai_service.
       service_endpoint: ""
-      # Optional endpoint override used only by the gateway for AAI_SERVICE_ENDPOINT.
-      # Leave empty to keep existing behavior and use service_endpoint (or embedded aai_service).
+      # Optional override for API auth checks.
+      # Use this when API auth should call a different endpoint than service_endpoint. Leave empty to use service_endpoint.
+      # (for example .../protocol/openid-connect/userinfo).
+      # - if it already ends with /userinfo, it is used as written
+      # - otherwise /oauth2/userinfo is added automatically
       gateway_endpoint: ""
 
     # Base URL path for the API gateway. Must start with / and end with /api/v1

--- a/pkg/k8s/config/render_test.go
+++ b/pkg/k8s/config/render_test.go
@@ -12,6 +12,7 @@ const (
 	externalAAIAuthRootURL      = "https://auth.example.com"
 	externalAAIUserinfoEndpoint = externalAAIAuthRootURL + "/oauth2/userinfo"
 	gatewayAAIUserinfoEndpoint  = "https://gateway-auth.example.com/oauth2/userinfo"
+	gatewayAAIKeycloakUserinfo  = "https://login.envri.eu/auth/realms/envri/protocol/openid-connect/userinfo"
 	dataportalTLSSecret         = "dataportal-tls"
 	gatewayTLSSecret            = "gateway-tls"
 	certManagerIssuerAnnotation = "cert-manager.io/cluster-issuer: letsencrypt"
@@ -188,6 +189,30 @@ func TestConfigRender(t *testing.T) {
 				"templates/gateway.yaml": {
 					`AAI_SERVICE_ENDPOINT: "` + externalAAIUserinfoEndpoint + `"`,
 					`AAI_SERVICE_ENDPOINT: "` + gatewayAAIUserinfoEndpoint + `/oauth2/userinfo"`,
+				},
+			},
+		},
+		{
+			name: "gateway endpoint keeps existing userinfo suffix",
+			mutate: func(cfg *config.Config) {
+				cfg.Name = "test-gateway-aai-keycloak-endpoint"
+				cfg.Components.Gateway.AAI.Enabled = true
+				cfg.Components.Gateway.AAI.ServiceEndpoint = externalAAIAuthRootURL
+				cfg.Components.Gateway.AAI.GatewayEndpoint = gatewayAAIKeycloakUserinfo + "/"
+			},
+			wantContains: map[string][]string{
+				"templates/gateway.yaml": {
+					`IS_AAI_ENABLED: "true"`,
+					`AAI_SERVICE_ENDPOINT: "` + gatewayAAIKeycloakUserinfo + `"`,
+				},
+				"templates/dataportal.yaml": {
+					`AUTH_ROOT_URL: "` + externalAAIAuthRootURL + `"`,
+				},
+			},
+			notContains: map[string][]string{
+				"templates/gateway.yaml": {
+					`AAI_SERVICE_ENDPOINT: "` + gatewayAAIKeycloakUserinfo + `/oauth2/userinfo"`,
+					`AAI_SERVICE_ENDPOINT: "` + externalAAIUserinfoEndpoint + `"`,
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
This fixes AAI endpoint handling so userinfo-style URLs (including Keycloak `/protocol/openid-connect/userinfo`) are preserved instead of having an extra `/oauth2/userinfo` appended. It keeps existing behavior for auth-root URLs by still deriving `/oauth2/userinfo` when needed, and updates default config comments to clearly describe how to configure `service_endpoint` and `gateway_endpoint`.

---

## Checklist

- [x] Builds locally with no errors (`make build`).
- [x] Linter passes (`make lint`) and tests pass (`make test`).
- [x] No secrets/keys/tokens added.
- [x] CLI behavior and flags remain backward compatible **or** breaking changes are documented here.
- [x] Docs/help/examples updated if behavior/flags changed.
- [x] Edge cases considered (empty inputs, timeouts, invalid paths).