### PR TITLE
feat(auth): configure AAI client redirect URLs

### DIFF
--- a/pkg/docker/config/config.go
+++ b/pkg/docker/config/config.go
@@ -119,6 +119,36 @@ func (e *EnvConfig) BuildEnvURLs() (*common.URLs, error) {
 	return urls, nil
 }
 
+// BackofficeURL returns the externally reachable backoffice base URL.
+func (e *EnvConfig) BackofficeURL() string {
+	base := &url.URL{
+		Scheme: e.Protocol,
+		Host:   net.JoinHostPort(e.Domain, strconv.Itoa(e.Components.Backoffice.GUI.Port)),
+	}
+
+	backofficeURL, err := url.JoinPath(base.String(), e.Components.Backoffice.GUI.BaseURL)
+	if err != nil {
+		return ""
+	}
+
+	return backofficeURL
+}
+
+// PlatformURL returns the externally reachable platform GUI base URL.
+func (e *EnvConfig) PlatformURL() string {
+	base := &url.URL{
+		Scheme: e.Protocol,
+		Host:   net.JoinHostPort(e.Domain, strconv.Itoa(e.Components.PlatformGUI.Port)),
+	}
+
+	platformURL, err := url.JoinPath(base.String(), e.Components.PlatformGUI.BaseURL)
+	if err != nil {
+		return ""
+	}
+
+	return platformURL
+}
+
 // CheckForUpdates checks configured container images for newer tags.
 func (e *EnvConfig) CheckForUpdates() ([]display.ImageUpdateInfo, error) {
 	updates, err := common.CheckImagesForUpdates(e.ActiveImages())

--- a/pkg/docker/config/render_test.go
+++ b/pkg/docker/config/render_test.go
@@ -50,8 +50,8 @@ func TestDockerEnvConfig_Render(t *testing.T) {
 			}(),
 			wantErr: false,
 			wantContains: map[string][]string{
-				".env":                {"AUTH_ROOT_URL=http://localhost:35000"},
-				"docker-compose.yaml": {"dataportal:", "backoffice-ui:", "- AUTH_ROOT_URL"},
+				".env":                {"AUTH_ROOT_URL=http://localhost:35000", "PLATFORM_URL=http://localhost:32000", "BACKOFFICE_URL=http://localhost:34000/backoffice"},
+				"docker-compose.yaml": {"dataportal:", "backoffice-ui:", "- AUTH_ROOT_URL", "BACKOFFICE_URL=${BACKOFFICE_URL}"},
 			},
 		},
 		{
@@ -103,13 +103,14 @@ func TestDockerEnvConfig_Render(t *testing.T) {
 					"IS_AAI_ENABLED=true",
 					"AAI_SERVICE_ENDPOINT=http://aai-service:8080/oauth2/userinfo",
 					"AUTH_ROOT_URL=http://localhost:35000",
+					"PLATFORM_URL=http://localhost:32000",
 					"ADMIN_NAME=EPOS",
 					"ADMIN_SURNAME=User",
 					"ADMIN_EMAIL=epos@epos.eu",
 					"ADMIN_PASSWORD=epos",
 					"AAI_SERVICE_PORT=35000",
 				},
-				"docker-compose.yaml": {"aai-service:", "${AAI_SERVICE_PORT}:8080"},
+				"docker-compose.yaml": {"aai-service:", "${AAI_SERVICE_PORT}:8080", "PLATFORM_URL=${PLATFORM_URL}"},
 			},
 		},
 		{

--- a/pkg/docker/config/templates/.env.tmpl
+++ b/pkg/docker/config/templates/.env.tmpl
@@ -4,6 +4,9 @@ PROTOCOL={{.Protocol}}
 DATAPORTAL_PATH={{.Components.PlatformGUI.BaseURL}}
 {{- if .Components.Backoffice.Enabled}}
 BACKOFFICE_PATH={{.Components.Backoffice.GUI.BaseURL}}
+{{- if .Components.AAIService.Enabled}}
+BACKOFFICE_URL={{.BackofficeURL}}
+{{- end}}
 {{- end}}
 API_PATH={{.Components.Gateway.BaseURL}}
 
@@ -72,6 +75,7 @@ ADMIN_NAME={{.Components.AAIService.Name}}
 ADMIN_SURNAME={{.Components.AAIService.Surname}}
 ADMIN_EMAIL={{.Components.AAIService.Email}}
 ADMIN_PASSWORD={{.Components.AAIService.Password}}
+PLATFORM_URL={{.PlatformURL}}
 {{- end}}
 
 # RabbitMQ Broker

--- a/pkg/docker/config/templates/docker-compose.yaml.tmpl
+++ b/pkg/docker/config/templates/docker-compose.yaml.tmpl
@@ -404,6 +404,10 @@ services:
       - INITIAL_ADMIN_EMAIL=${ADMIN_EMAIL}
       - INITIAL_ADMIN_PASSWORD=${ADMIN_PASSWORD}
       - APP_CORS_ALLOW_ORIGIN=*
+      - PLATFORM_URL=${PLATFORM_URL}
+      {{- if .Components.Backoffice.Enabled}}
+      - BACKOFFICE_URL=${BACKOFFICE_URL}
+      {{- end}}
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:8080/healthz || exit 1"]
       interval: 10s

--- a/pkg/k8s/config/helm/templates/_helpers.tpl
+++ b/pkg/k8s/config/helm/templates/_helpers.tpl
@@ -91,6 +91,30 @@ jdbc:postgresql://{{ default .Values.components.metadata_database.host }}:{{ .Va
 {{- end -}}
 {{- end -}}
 
+{{- define "epos.backofficeBasePath" -}}
+{{- if .Values.url_prefix_namespace -}}
+{{- printf "/%s%s" .Release.Namespace .Values.components.backoffice.gui.base_url -}}
+{{- else -}}
+{{- .Values.components.backoffice.gui.base_url -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "epos.backofficeURL" -}}
+{{- printf "%s://%s%s" .Values.protocol .Values.domain (include "epos.backofficeBasePath" .) -}}
+{{- end -}}
+
+{{- define "epos.platformBasePath" -}}
+{{- if .Values.url_prefix_namespace -}}
+{{- printf "/%s%s" .Release.Namespace .Values.components.platform_gui.base_url -}}
+{{- else -}}
+{{- .Values.components.platform_gui.base_url -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "epos.platformURL" -}}
+{{- printf "%s://%s%s" .Values.protocol .Values.domain (include "epos.platformBasePath" .) -}}
+{{- end -}}
+
 {{- define "epos.aaiAuthRootURL" -}}
 {{- $endpoint := .Values.components.gateway.aai.service_endpoint | default "" | trim | trimSuffix "/" | trimSuffix "/oauth2/userinfo" -}}
 {{- if $endpoint -}}

--- a/pkg/k8s/config/helm/templates/aai-service.yaml
+++ b/pkg/k8s/config/helm/templates/aai-service.yaml
@@ -9,6 +9,11 @@ INITIAL_ADMIN_SURNAME: {{ .Values.components.aai_service.surname | quote }}
 INITIAL_ADMIN_EMAIL: {{ .Values.components.aai_service.email | quote }}
 INITIAL_ADMIN_PASSWORD: {{ .Values.components.aai_service.password | quote }}
 APP_CORS_ALLOW_ORIGIN: "*"
+OIDC_ISSUER: {{ printf "%s/oauth2" (include "epos.defaultAAIAuthRootURL" .) | quote }}
+PLATFORM_URL: {{ include "epos.platformURL" . | quote }}
+{{- if .Values.components.backoffice.enabled }}
+BACKOFFICE_URL: {{ include "epos.backofficeURL" . | quote }}
+{{- end }}
 {{- end -}}
 
 {{- if .Values.components.aai_service.enabled }}

--- a/pkg/k8s/config/helm/templates/backoffice-ui.yaml
+++ b/pkg/k8s/config/helm/templates/backoffice-ui.yaml
@@ -1,9 +1,5 @@
 {{- define "epos.backofficeUIConfigData" -}}
-{{- if .Values.url_prefix_namespace }}
-BASE_URL: /{{ .Release.Namespace }}{{ .Values.components.backoffice.gui.base_url }}
-{{- else }}
-BASE_URL: {{ .Values.components.backoffice.gui.base_url }}
-{{- end }}
+BASE_URL: {{ include "epos.backofficeBasePath" . }}
 API_HOST: http://gateway:5000/api
 AUTH_ROOT_URL: {{ include "epos.aaiAuthRootURL" . | quote }}
 {{- end -}}
@@ -73,11 +69,7 @@ metadata:
     {{- include "epos.labels" . | nindent 4 }}
     app.kubernetes.io/component: backoffice-ui
   annotations:
-    {{- if .Values.url_prefix_namespace }}
-    nginx.ingress.kubernetes.io/rewrite-target: /{{ .Release.Namespace }}{{ .Values.components.backoffice.gui.base_url }}
-    {{- else }}
-    nginx.ingress.kubernetes.io/rewrite-target: {{ .Values.components.backoffice.gui.base_url }}
-    {{- end }}
+    nginx.ingress.kubernetes.io/rewrite-target: {{ include "epos.backofficeBasePath" . }}
 
     {{- if and .Values.components.backoffice.tls.enabled .Values.cert_manager_issuer }}
     cert-manager.io/cluster-issuer: {{ .Values.cert_manager_issuer }}
@@ -88,11 +80,7 @@ spec:
   - host: {{ .Values.domain }}
     http:
       paths:
-      {{- if .Values.url_prefix_namespace }}
-      - path: /{{ .Release.Namespace }}{{ .Values.components.backoffice.gui.base_url }}
-      {{- else }}
-      - path: {{ .Values.components.backoffice.gui.base_url }}
-      {{- end }}
+      - path: {{ include "epos.backofficeBasePath" . }}
         pathType: Prefix
         backend:
           service:

--- a/pkg/k8s/config/helm/templates/dataportal.yaml
+++ b/pkg/k8s/config/helm/templates/dataportal.yaml
@@ -1,9 +1,5 @@
 {{- define "epos.dataportalConfigData" -}}
-{{- if .Values.url_prefix_namespace }}
-BASE_URL: /{{ .Release.Namespace }}{{ .Values.components.platform_gui.base_url }}
-{{- else }}
-BASE_URL: {{ .Values.components.platform_gui.base_url }}
-{{- end }}
+BASE_URL: {{ include "epos.platformBasePath" . }}
 API_HOST: http://gateway:5000/api
 AUTH_ROOT_URL: {{ include "epos.aaiAuthRootURL" . | quote }}
 {{- end -}}
@@ -70,11 +66,7 @@ metadata:
     {{- include "epos.labels" . | nindent 4 }}
     app.kubernetes.io/component: dataportal
   annotations:
-    {{- if .Values.url_prefix_namespace }}
-    nginx.ingress.kubernetes.io/rewrite-target: /{{ .Release.Namespace }}{{ .Values.components.platform_gui.base_url }}
-    {{- else }}
-    nginx.ingress.kubernetes.io/rewrite-target: {{ .Values.components.platform_gui.base_url }}
-    {{- end }}
+    nginx.ingress.kubernetes.io/rewrite-target: {{ include "epos.platformBasePath" . }}
 
     {{- if and .Values.components.platform_gui.tls.enabled .Values.cert_manager_issuer }}
     cert-manager.io/cluster-issuer: {{ .Values.cert_manager_issuer }}
@@ -85,11 +77,7 @@ spec:
   - host: {{ .Values.domain }}
     http:
       paths:
-      {{- if .Values.url_prefix_namespace }}
-      - path: /{{ .Release.Namespace }}{{ .Values.components.platform_gui.base_url }}
-      {{- else }}
-      - path: {{ .Values.components.platform_gui.base_url }}
-      {{- end }}
+      - path: {{ include "epos.platformBasePath" . }}
         pathType: Prefix
         backend:
           service:

--- a/pkg/k8s/config/render_test.go
+++ b/pkg/k8s/config/render_test.go
@@ -123,6 +123,7 @@ func TestConfigRender(t *testing.T) {
 				cfg.Name = "test-aai"
 				cfg.Components.Gateway.AAI.Enabled = true
 				cfg.Components.AAIService.Enabled = true
+				cfg.Components.Backoffice.Enabled = true
 			},
 			wantContains: map[string][]string{
 				"templates/gateway.yaml": {
@@ -142,8 +143,26 @@ func TestConfigRender(t *testing.T) {
 					`INITIAL_ADMIN_EMAIL: "epos@epos.eu"`,
 					`INITIAL_ADMIN_PASSWORD: "epos"`,
 					`APP_CORS_ALLOW_ORIGIN: "*"`,
+					`PLATFORM_URL: "http://localhost/test-aai/"`,
+					`BACKOFFICE_URL: "http://localhost/test-aai/backoffice/"`,
 				},
 				"templates/pvc.yaml": {"name: aai"},
+			},
+		},
+		{
+			name: "embedded aai backoffice URL omits namespace when prefix is disabled",
+			mutate: func(cfg *config.Config) {
+				cfg.Name = "test-aai-no-prefix"
+				cfg.URLPrefixNamespace = false
+				cfg.Components.Gateway.AAI.Enabled = true
+				cfg.Components.AAIService.Enabled = true
+				cfg.Components.Backoffice.Enabled = true
+			},
+			wantContains: map[string][]string{
+				"templates/aai-service.yaml": {
+					`PLATFORM_URL: "http://localhost/"`,
+					`BACKOFFICE_URL: "http://localhost/backoffice/"`,
+				},
 			},
 		},
 		{


### PR DESCRIPTION
# feat(auth): configure AAI client redirect URLs

## Summary

Configure embedded AAI with platform and optional backoffice URLs.
Share Kubernetes URL path rendering to keep namespace prefixes consistent.

---

## Checklist

- [x] Builds locally with no errors (`make build`).
- [x] Linter passes (`make lint`) and tests pass (`make test`).
- [x] No secrets/keys/tokens added.
- [x] CLI behavior and flags remain backward compatible.
- [x] Docs/help/examples unchanged; no CLI behavior or flags changed.
- [x] Edge cases considered: namespace-prefixed and unprefixed URLs.
