### PR TITLE
fix(tui): preserve k8s context display

### DIFF
--- a/tui/envlist.go
+++ b/tui/envlist.go
@@ -296,7 +296,7 @@ func (el *EnvList) applyK8sData(data k8sListData) {
 	} else {
 		el.k8sFlexInner.AddItem(el.k8s, 0, 1, true)
 		for _, env := range el.k8sEnvs {
-			item := "[::b] • " + env.Name + "  [" + env.Context + "] "
+			item := "[::b] • " + tview.Escape(env.Name+"  ["+env.Context+"] ")
 			el.k8s.AddItem(item, "", 0, nil)
 		}
 


### PR DESCRIPTION
## Summary
Escape K8s list text so contexts remain visible in square brackets.

---

## Checklist
- [x] Builds locally with no errors (`make build`).
- [x] Linter and tests pass.
- [x] No secrets added.
- [x] CLI behavior unchanged.