### PR TITLE
fix(tui): restore modal form focus

### DIFF
--- a/tui/app.go
+++ b/tui/app.go
@@ -637,8 +637,8 @@ func (a *App) ShowModalForm(opts ModalFormOptions) {
 			return false
 		}
 
-		a.tview.SetFocus(form)
 		form.SetFocus(0)
+		a.tview.SetFocus(form)
 
 		return true
 	}
@@ -648,8 +648,8 @@ func (a *App) ShowModalForm(opts ModalFormOptions) {
 			return false
 		}
 
-		a.tview.SetFocus(form)
 		form.SetFocus(formItemCount - 1)
+		a.tview.SetFocus(form)
 
 		return true
 	}


### PR DESCRIPTION
## Summary

Restore form item focus before assigning application focus, preventing stale checkbox focus during Tab/Shift+Tab navigation.

## Checklist

- [x] Linter passes and tests pass.
- [x] No secrets/keys/tokens added.
- [x] CLI behavior and flags remain backward compatible.