### PR TITLE
fix(tui): preserve env list during refresh

### DIFF
--- a/tui/app.go
+++ b/tui/app.go
@@ -195,22 +195,17 @@ func (a *App) run() error {
 
 // startRefreshTicker starts background list refresh every 3 seconds.
 func (a *App) startRefreshTicker() {
-	a.refreshEnvListsAsync(false)
+	a.refreshEnvListsAsync()
 
 	a.refreshTicker = time.NewTicker(3 * time.Second)
 	go func() {
 		for range a.refreshTicker.C {
-			a.refreshEnvListsAsync(false)
+			a.refreshEnvListsAsync()
 		}
 	}()
 }
 
-func (a *App) refreshEnvListsAsync(showLoading bool) {
-	if showLoading {
-		a.envList.showDockerLoading()
-		a.envList.showK8sLoading()
-	}
-
+func (a *App) refreshEnvListsAsync() {
 	a.refreshDockerAsync()
 	a.refreshK8sAsync()
 }
@@ -357,7 +352,7 @@ func (a *App) ResetToHome(opts ResetOptions) {
 
 	a.pages.SwitchToPage(homePageName)
 	a.currentPage = homePageName
-	a.refreshEnvListsAsync(true)
+	a.refreshEnvListsAsync()
 
 	if opts.RefreshFiles {
 		a.detailsPanel.RefreshFiles()


### PR DESCRIPTION
## Summary
Keep current environment lists visible during async refresh; replace them when fresh data arrives.

## Checklist

- [x] Builds locally with no errors (`make build`).
- [x] Linter passes (`make lint`) and tests pass (`make test`).
- [x] No secrets/keys/tokens added.
- [x] CLI behavior and flags remain backward compatible or breaking changes are documented here.
- [x] Docs/help/examples updated if behavior/flags changed.
- [x] Edge cases considered (empty inputs, timeouts, invalid paths).
